### PR TITLE
Matching engine performance tests using JMH

### DIFF
--- a/parity-perf-test/pom.xml
+++ b/parity-perf-test/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>parity</groupId>
+    <artifactId>parity-parent</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>parity</groupId>
+  <artifactId>parity-perf-test</artifactId>
+
+  <name>Parity Performance Tests</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>parity</groupId>
+      <artifactId>parity-match</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>0.5.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>0.5.6</version>
+      <scope>provided</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>microbenchmarks</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/parity-perf-test/src/main/java/parity/perf/MarketBenchmark.java
+++ b/parity-perf-test/src/main/java/parity/perf/MarketBenchmark.java
@@ -1,0 +1,54 @@
+package parity.perf;
+
+import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Mode;
+import java.util.concurrent.TimeUnit;
+import parity.match.MarketListener;
+import parity.match.Market;
+import parity.match.Side;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class MarketBenchmark {
+
+    private long sequence;
+    private Market market;
+
+    @Setup(Level.Iteration)
+    public void prepare() {
+        MarketListener listener = new MarketListener() {
+            public void match(long restingOrderId, long incomingOrderId, int quantity) {
+            }
+            public void add(long orderId, Side side, long price, int size) {
+            }
+            public void cancel(long orderId, int quantity) {
+            }
+            public void delete(long orderId) {
+            }
+        };
+
+        market = new Market(listener);
+
+        sequence = 0;
+    }
+
+    @GenerateMicroBenchmark
+    @BenchmarkMode(Mode.SampleTime)
+    public void testEnterOrder() {
+        market.enter(sequence++, Side.BUY, 34090, 100);
+    }
+
+    @GenerateMicroBenchmark
+    @BenchmarkMode(Mode.SampleTime)
+    public void testEnterAndDeleteOrder() {
+        long id = sequence++;
+        market.enter(id, Side.BUY, 34090, 100);
+        market.delete(id);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
   <modules>
     <module>parity-match</module>
     <module>parity-util</module>
+    <module>parity-perf-test</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
This adds microbenchmarks for the matching engine using JMH.

To run it, type:

  mvn install

and then:

  java -jar parity-perf-test/target/microbenchmarks.jar

Signed-off-by: Pekka Enberg penberg@iki.fi
