### PR TITLE
Add BinaryFILE support to stock ticker

### DIFF
--- a/parity-ticker/README.md
+++ b/parity-ticker/README.md
@@ -10,11 +10,15 @@ Usage
 
 Run Parity Stock Ticker with Java:
 
-    java -jar <executable> [-t] <configuration-file>
+    java -jar <executable> <command>
 
-After starting, the stock ticker first replays market events that have taken
-place before it started. Then it proceeds to display market events in real
-time.
+To listen to a live market data feed, use the `listen` command:
+
+    java -jar <executable> listen [-t] <configuration-file>
+
+When listening to a live market data feed, the stock ticker first replays
+market events that have taken place before it started. Then it proceeds to
+display market events in real time.
 
 By default, the stock ticker formats its output for display. If the `-t`
 option is given, it formats the output as [TAQ][] instead.

--- a/parity-ticker/README.md
+++ b/parity-ticker/README.md
@@ -20,6 +20,10 @@ When listening to a live market data feed, the stock ticker first replays
 market events that have taken place before it started. Then it proceeds to
 display market events in real time.
 
+To read a historical market data file, use the `read` command:
+
+    java -jar <executable> read [-t] <input-file> [<instrument> ...]
+
 By default, the stock ticker formats its output for display. If the `-t`
 option is given, it formats the output as [TAQ][] instead.
 

--- a/parity-ticker/src/main/java/com/paritytrading/parity/ticker/Command.java
+++ b/parity-ticker/src/main/java/com/paritytrading/parity/ticker/Command.java
@@ -1,0 +1,14 @@
+package com.paritytrading.parity.ticker;
+
+import java.io.IOException;
+import java.util.List;
+
+interface Command {
+
+    void execute(List<String> arguments) throws IOException;
+
+    String getName();
+
+    String getDescription();
+
+}

--- a/parity-ticker/src/main/java/com/paritytrading/parity/ticker/ListenCommand.java
+++ b/parity-ticker/src/main/java/com/paritytrading/parity/ticker/ListenCommand.java
@@ -1,0 +1,90 @@
+package com.paritytrading.parity.ticker;
+
+import static org.jvirtanen.util.Applications.*;
+
+import com.paritytrading.foundation.ASCII;
+import com.paritytrading.nassau.MessageListener;
+import com.paritytrading.parity.net.pmd.PMDParser;
+import com.paritytrading.parity.top.Market;
+import com.paritytrading.parity.util.MoldUDP64;
+import com.paritytrading.parity.util.SoupBinTCP;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.util.List;
+import org.jvirtanen.config.Configs;
+
+class ListenCommand implements Command {
+
+    private static final String USAGE = "parity-ticker listen [-t] <configuration-file>";
+
+    @Override
+    public void execute(List<String> arguments) throws IOException {
+        if (arguments.size() == 0 || arguments.size() > 2)
+            usage(USAGE);
+
+        boolean taq = false;
+
+        if (arguments.size() == 2) {
+            if (!arguments.get(0).equals("-t"))
+                usage(USAGE);
+            taq = true;
+        }
+
+        try {
+            execute(config(arguments.get(taq ? 1 : 0)), taq);
+        } catch (ConfigException | FileNotFoundException e) {
+            error(e);
+        }
+    }
+
+    private void execute(Config config, boolean taq) throws IOException {
+        List<String> instruments = config.getStringList("instruments");
+
+        MarketDataListener listener = taq ? new TAQFormat() : new DisplayFormat(instruments);
+
+        Market market = new Market(listener);
+
+        for (String instrument : instruments)
+            market.open(ASCII.packLong(instrument));
+
+        MarketDataProcessor processor = new MarketDataProcessor(market, listener);
+
+        execute(config, new PMDParser(processor));
+    }
+
+    private void execute(Config config, MessageListener listener) throws IOException {
+        if (config.hasPath("market-data.multicast-interface")) {
+            NetworkInterface multicastInterface = Configs.getNetworkInterface(config, "market-data.multicast-interface");
+            InetAddress      multicastGroup     = Configs.getInetAddress(config, "market-data.multicast-group");
+            int              multicastPort      = Configs.getPort(config, "market-data.multicast-port");
+            InetAddress      requestAddress     = Configs.getInetAddress(config, "market-data.request-address");
+            int              requestPort        = Configs.getPort(config, "market-data.request-port");
+
+            MoldUDP64.receive(multicastInterface, new InetSocketAddress(multicastGroup, multicastPort),
+                    new InetSocketAddress(requestAddress, requestPort), listener);
+        } else {
+            InetAddress address  = Configs.getInetAddress(config, "market-data.address");
+            int         port     = Configs.getPort(config, "market-data.port");
+            String      username = config.getString("market-data.username");
+            String      password = config.getString("market-data.password");
+
+            SoupBinTCP.receive(new InetSocketAddress(address, port), username, password, listener);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "listen";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Listen to a live market data feed";
+    }
+
+}

--- a/parity-ticker/src/main/java/com/paritytrading/parity/ticker/ReadCommand.java
+++ b/parity-ticker/src/main/java/com/paritytrading/parity/ticker/ReadCommand.java
@@ -1,0 +1,67 @@
+package com.paritytrading.parity.ticker;
+
+import static org.jvirtanen.util.Applications.*;
+
+import com.paritytrading.foundation.ASCII;
+import com.paritytrading.parity.net.pmd.PMDParser;
+import com.paritytrading.parity.top.Market;
+import com.paritytrading.parity.util.BinaryFILE;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+class ReadCommand implements Command {
+
+    private static final String USAGE = "parity-ticker read [-t] <input-file> [<instrument> ...]";
+
+    @Override
+    public void execute(List<String> arguments) throws IOException {
+        if (arguments.size() == 0)
+            usage(USAGE);
+
+        boolean taq = false;
+
+        String filename = arguments.get(0);
+
+        int i = 1;
+
+        if (filename.equals("-t")) {
+            if (arguments.size() == 1)
+                usage(USAGE);
+
+            taq = true;
+
+            filename = arguments.get(1);
+
+            i = 2;
+        }
+
+        List<String> instruments = arguments.subList(i, arguments.size());
+
+        execute(new File(filename), instruments, taq);
+    }
+
+    private void execute(File file, List<String> instruments, boolean taq) throws IOException {
+        MarketDataListener listener = taq ? new TAQFormat() : new DisplayFormat(instruments);
+
+        Market market = new Market(listener);
+
+        for (String instrument : instruments)
+            market.open(ASCII.packLong(instrument));
+
+        MarketDataProcessor processor = new MarketDataProcessor(market, listener);
+
+        BinaryFILE.read(file, new PMDParser(processor));
+    }
+
+    @Override
+    public String getName() {
+        return "read";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Read a historical market data file";
+    }
+
+}

--- a/parity-ticker/src/main/java/com/paritytrading/parity/ticker/StockTicker.java
+++ b/parity-ticker/src/main/java/com/paritytrading/parity/ticker/StockTicker.java
@@ -1,9 +1,11 @@
 package com.paritytrading.parity.ticker;
 
 import static java.util.Arrays.*;
+import static java.util.Comparator.*;
 import static org.jvirtanen.util.Applications.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,6 +16,7 @@ class StockTicker {
 
     static {
         COMMANDS.put("listen", new ListenCommand());
+        COMMANDS.put("read",   new ReadCommand());
     }
 
     public static void main(String[] args) {
@@ -34,11 +37,17 @@ class StockTicker {
     }
 
     private static void usage() {
+        List<Command> commands = new ArrayList<>(COMMANDS.values());
+
+        commands.sort(comparing(c -> c.getName()));
+
+        int maxCommandNameLength = commands.stream().mapToInt(c -> c.getName().length()).max().orElse(0);
+
         System.err.printf("Usage: parity-ticker <command>\n\n");
         System.err.printf("Commands:\n");
 
-        for (Command command : COMMANDS.values())
-            System.err.printf("  %s  %s\n", command.getName(), command.getDescription());
+        for (Command command : commands)
+            System.err.printf("  %-" + maxCommandNameLength + "s  %s\n", command.getName(), command.getDescription());
 
         System.err.printf("\n");
         System.exit(2);

--- a/parity-util/src/main/java/com/paritytrading/parity/util/BinaryFILE.java
+++ b/parity-util/src/main/java/com/paritytrading/parity/util/BinaryFILE.java
@@ -1,0 +1,40 @@
+package com.paritytrading.parity.util;
+
+import com.paritytrading.nassau.MessageListener;
+import com.paritytrading.nassau.binaryfile.BinaryFILEReader;
+import com.paritytrading.nassau.binaryfile.BinaryFILEStatusListener;
+import com.paritytrading.nassau.binaryfile.BinaryFILEStatusParser;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * This class contains utility methods for BinaryFILE.
+ */
+public class BinaryFILE {
+
+    private BinaryFILE() {
+    }
+
+    /**
+     * Read messages.
+     *
+     * @param file a file
+     * @param listener a message listener
+     * @throws IOException if an I/O error occurs
+     */
+    public static void read(File file, MessageListener listener) throws IOException {
+        BinaryFILEStatusListener statusListener = new BinaryFILEStatusListener() {
+
+            @Override
+            public void endOfSession() {
+            }
+
+        };
+
+        BinaryFILEStatusParser statusParser = new BinaryFILEStatusParser(listener, statusListener);
+
+        try (BinaryFILEReader reader = BinaryFILEReader.open(file, statusParser)) {
+            while (reader.read());
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>2.3</version>
+          <version>2.4.3</version>
           <configuration>
             <createDependencyReducedPom>false</createDependencyReducedPom>
             <minimizeJar>true</minimizeJar>


### PR DESCRIPTION
Make it possible to read a historical market data file with the stock ticker.

The file format is NASDAQ BinaryFILE 1.00 containing [PMD](https://github.com/paritytrading/parity/blob/master/parity-net/doc/PMD.md) messages. Such files can be created with [Nassau BinaryFILE Recorder](https://github.com/paritytrading/nassau/tree/master/nassau-binaryfile-recorder), for example.