### PR TITLE
Expose remaining quantity in order book reconstruction

### DIFF
--- a/parity-book/src/main/java/com/paritytrading/parity/book/Market.java
+++ b/parity-book/src/main/java/com/paritytrading/parity/book/Market.java
@@ -128,13 +128,14 @@ public class Market {
      *
      * @param orderId the order identifier
      * @param quantity the executed quantity
+     * @return the remaining quantity
      */
-    public void execute(long orderId, long quantity) {
+    public long execute(long orderId, long quantity) {
         Order order = orders.get(orderId);
         if (order == null)
-            return;
+            return 0;
 
-        execute(orderId, order, quantity, order.getPrice());
+        return execute(orderId, order, quantity, order.getPrice());
     }
 
     /**
@@ -148,16 +149,17 @@ public class Market {
      * @param orderId the order identifier
      * @param quantity the executed quantity
      * @param price the execution price
+     * @return the remaining quantity
      */
-    public void execute(long orderId, long quantity, long price) {
+    public long execute(long orderId, long quantity, long price) {
         Order order = orders.get(orderId);
         if (order == null)
-            return;
+            return 0;
 
-        execute(orderId, order, quantity, price);
+        return execute(orderId, order, quantity, price);
     }
 
-    private void execute(long orderId, Order order, long quantity, long price) {
+    private long execute(long orderId, Order order, long quantity, long price) {
         OrderBook book = order.getOrderBook();
 
         Side side = order.getSide();
@@ -176,6 +178,8 @@ public class Market {
             order.reduce(executedQuantity);
 
         listener.update(book, true);
+
+        return remainingQuantity - executedQuantity;
     }
 
     /**
@@ -188,11 +192,12 @@ public class Market {
      *
      * @param orderId the order identifier
      * @param quantity the canceled quantity
+     * @return the remaining quantity
      */
-    public void cancel(long orderId, long quantity) {
+    public long cancel(long orderId, long quantity) {
         Order order = orders.get(orderId);
         if (order == null)
-            return;
+            return 0;
 
         OrderBook book = order.getOrderBook();
 
@@ -208,6 +213,8 @@ public class Market {
             order.reduce(canceledQuantity);
 
         listener.update(book, bbo);
+
+        return remainingQuantity - canceledQuantity;
     }
 
     /**

--- a/parity-book/src/test/java/com/paritytrading/parity/book/MarketTest.java
+++ b/parity-book/src/test/java/com/paritytrading/parity/book/MarketTest.java
@@ -81,7 +81,7 @@ public class MarketTest {
         market.add(INSTRUMENT, 1, Side.BUY,   999, 100);
         market.add(INSTRUMENT, 2, Side.SELL, 1001, 200);
         market.add(INSTRUMENT, 3, Side.SELL, 1002,  50);
-        market.execute(2, 200);
+        assertEquals(0, market.execute(2, 200));
 
         assertEquals(asList(new Level(999, 100, 1002, 50)), levels(book));
 
@@ -100,7 +100,7 @@ public class MarketTest {
         market.add(INSTRUMENT, 1, Side.BUY,   999, 100);
         market.add(INSTRUMENT, 2, Side.SELL, 1001, 200);
         market.add(INSTRUMENT, 3, Side.SELL, 1002,  50);
-        market.execute(2, 200, 1000);
+        assertEquals(0, market.execute(2, 200, 1000));
 
         assertEquals(asList(new Level(999, 100, 1002, 50)), levels(book));
 
@@ -118,7 +118,7 @@ public class MarketTest {
     public void partialExecution() {
         market.add(INSTRUMENT, 1, Side.BUY,   999, 100);
         market.add(INSTRUMENT, 2, Side.SELL, 1001, 200);
-        market.execute(2, 100);
+        assertEquals(100, market.execute(2, 100));
 
         assertEquals(asList(new Level(999, 100, 1001, 100)), levels(book));
 
@@ -136,7 +136,7 @@ public class MarketTest {
         market.add(INSTRUMENT, 1, Side.BUY,   999, 100);
         market.add(INSTRUMENT, 2, Side.SELL, 1001, 200);
         market.add(INSTRUMENT, 3, Side.SELL, 1002,  50);
-        market.cancel(2, 200);
+        assertEquals(0, market.cancel(2, 200));
 
         assertEquals(asList(new Level(999, 100, 1002, 50)), levels(book));
 
@@ -153,7 +153,7 @@ public class MarketTest {
     public void partialCancellation() {
         market.add(INSTRUMENT, 1, Side.BUY,   999, 100);
         market.add(INSTRUMENT, 2, Side.SELL, 1001, 200);
-        market.cancel(2, 100);
+        assertEquals(100, market.cancel(2, 100));
 
         assertEquals(asList(new Level(999, 100, 1001, 100)), levels(book));
 


### PR DESCRIPTION
Sometimes it is useful to know whether an order still exists in the order book after a cancellation or an  execution.