### PR TITLE
Add configuration for TAQ file format

### DIFF
--- a/parity-file/doc/TAQ.md
+++ b/parity-file/doc/TAQ.md
@@ -23,7 +23,8 @@ Dates are represented as `YYYY-MM-DD` (ISO 8601).
 
 Timestamps are represented as `HH:MM:SS.SSS` (ISO 8601).
 
-Prices are represented as decimal numbers using decimal point.
+Prices and sizes are represented either as integers or as decimal numbers
+using decimal point.
 
 
 Records

--- a/parity-file/src/main/java/com/paritytrading/parity/file/taq/TAQ.java
+++ b/parity-file/src/main/java/com/paritytrading/parity/file/taq/TAQ.java
@@ -46,7 +46,7 @@ public class TAQ {
         /**
          * The bid size or zero if no bid size is available.
          */
-        public long bidSize;
+        public double bidSize;
 
         /**
          * The ask price or zero if no ask price is available.
@@ -56,7 +56,7 @@ public class TAQ {
         /**
          * The ask size or zero if no ask size is available.
          */
-        public long askSize;
+        public double askSize;
     }
 
     /**
@@ -87,7 +87,7 @@ public class TAQ {
         /**
          * The trade size.
          */
-        public long size;
+        public double size;
 
         /**
          * The side of the resting order or <code>UNKNOWN</code> if the side

--- a/parity-file/src/main/java/com/paritytrading/parity/file/taq/TAQConfig.java
+++ b/parity-file/src/main/java/com/paritytrading/parity/file/taq/TAQConfig.java
@@ -1,0 +1,140 @@
+package com.paritytrading.parity.file.taq;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+import java.nio.charset.Charset;
+
+/**
+ * A configuration.
+ */
+public class TAQConfig {
+
+    /**
+     * The default configuration.
+     */
+    public static final TAQConfig DEFAULTS = new TAQConfig.Builder().build();
+
+    private Charset encoding;
+
+    private int priceFractionDigits;
+    private int sizeFractionDigits;
+
+    /**
+     * Create a new configuration.
+     *
+     * @param encoding the encoding
+     * @param priceFractionDigits the number of digits in the fractional part
+     *   of a price
+     * @param sizeFractionDigits the number of digits in the fractional part
+     *   of a size
+     */
+    public TAQConfig(Charset encoding, int priceFractionDigits, int sizeFractionDigits) {
+        this.encoding = encoding;
+
+        this.priceFractionDigits = priceFractionDigits;
+        this.sizeFractionDigits  = sizeFractionDigits;
+    }
+
+    /**
+     * Get the encoding.
+     *
+     * @return the encoding
+     */
+    public Charset getEncoding() {
+        return encoding;
+    }
+
+    /**
+     * Get the number of digits in the fractional part of a price.
+     *
+     * @return the number of digits in the fractional part of a size
+     */
+    public int getPriceFractionDigits() {
+        return priceFractionDigits;
+    }
+
+    /**
+     * Get the number of digits in the fractional part of a size.
+     *
+     * @return the number of digits in the fractional part of a size
+     */
+    public int getSizeFractionDigits() {
+        return sizeFractionDigits;
+    }
+
+    /**
+     * A configuration builder. The builder uses the following default values:
+     *
+     * <ul>
+     *   <li>the encoding: US-ASCII</li>
+     *   <li>the number of digits in the fractional part of a price: 2</li>
+     *   <li>the number of digits in the fractional part of a size: 0</li>
+     * </ul>
+     */
+    public static class Builder {
+
+        private Charset encoding;
+
+        private int priceFractionDigits;
+        private int sizeFractionDigits;
+
+        /**
+         * Create a configuration builder.
+         */
+        public Builder() {
+            encoding = US_ASCII;
+
+            priceFractionDigits = 2;
+            sizeFractionDigits  = 0;
+        }
+
+        /**
+         * Set the character set.
+         *
+         * @param cs the character set
+         * @return this instance
+         */
+        public Builder setEncoding(Charset encoding) {
+            this.encoding = encoding;
+
+            return this;
+        }
+
+        /**
+         * Set the number of digits in the fractional part of a price.
+         *
+         * @param priceFractionDigits the number of digits in the fractional
+         *     part of a price
+         * @return this instance
+         */
+        public Builder setPriceFractionDigits(int priceFractionDigits) {
+            this.priceFractionDigits = priceFractionDigits;
+
+            return this;
+        }
+
+        /**
+         * Set the number of digits in the fractional part of a size.
+         *
+         * @param sizeFractionDigits the number of digits in the fractional
+         *     part of a size
+         * @return this instance
+         */
+        public Builder setSizeFractionDigits(int sizeFractionDigits) {
+            this.sizeFractionDigits = sizeFractionDigits;
+
+            return this;
+        }
+
+        /**
+         * Build the configuration.
+         *
+         * @return the configuration
+         */
+        public TAQConfig build() {
+            return new TAQConfig(encoding, priceFractionDigits, sizeFractionDigits);
+        }
+
+    }
+
+}

--- a/parity-file/src/main/java/com/paritytrading/parity/file/taq/TAQWriter.java
+++ b/parity-file/src/main/java/com/paritytrading/parity/file/taq/TAQWriter.java
@@ -1,7 +1,6 @@
 package com.paritytrading.parity.file.taq;
 
 import static com.paritytrading.parity.file.taq.TAQ.*;
-import static java.nio.charset.StandardCharsets.*;
 
 import com.paritytrading.parity.util.Timestamps;
 import java.io.BufferedOutputStream;
@@ -14,7 +13,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
-import java.nio.charset.Charset;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.FieldPosition;
@@ -53,39 +51,57 @@ public class TAQWriter implements Closeable, Flushable {
     private PrintWriter sink;
 
     /**
-     * Create a writer that writes to the specified file.
+     * Create a writer that writes to the specified file using the default
+     * configuration.
      *
      * @param file a file
      * @throws FileNotFoundException if the file cannot be opened
      */
     public TAQWriter(File file) throws FileNotFoundException {
-        this(new BufferedOutputStream(new FileOutputStream(file)));
+        this(file, TAQConfig.DEFAULTS);
+    }
+
+    /**
+     * Create a writer that writes to the specified file.
+     *
+     * @param file a file
+     * @param config the configuration
+     * @throws FileNotFoundException if the file cannot be opened
+     */
+    public TAQWriter(File file, TAQConfig config) throws FileNotFoundException {
+        this(new BufferedOutputStream(new FileOutputStream(file)), config);
     }
 
     /**
      * Create a writer that writes to the specified output stream using the
-     * default encoding for TAQ, ASCII.
+     * default configuration.
      *
      * @param out an output stream
      */
     public TAQWriter(OutputStream out) {
-        this(out, US_ASCII);
+        this(out, TAQConfig.DEFAULTS);
     }
 
     /**
-     * Create a writer that writes to the specified output stream using the
-     * specified encoding.
+     * Create a writer that writes to the specified output stream.
      *
      * @param out an output stream
-     * @param cs a charset
+     * @param config the configuration
      */
-    public TAQWriter(OutputStream out, Charset cs) {
-        this(new OutputStreamWriter(out, cs));
+    public TAQWriter(OutputStream out, TAQConfig config) {
+        this(new OutputStreamWriter(out, config.getEncoding()), config);
     }
 
-    private TAQWriter(Writer writer) {
+    private TAQWriter(Writer writer, TAQConfig config) {
         priceFormat = new DecimalFormat("0.00", SYMBOLS);
+
+        priceFormat.setMinimumFractionDigits(config.getPriceFractionDigits());
+        priceFormat.setMaximumFractionDigits(config.getPriceFractionDigits());
+
         sizeFormat  = new DecimalFormat("0", SYMBOLS);
+
+        sizeFormat.setMinimumFractionDigits(config.getSizeFractionDigits());
+        sizeFormat.setMaximumFractionDigits(config.getSizeFractionDigits());
 
         position = new FieldPosition(NumberFormat.INTEGER_FIELD);
 

--- a/parity-file/src/main/java/com/paritytrading/parity/file/taq/TAQWriter.java
+++ b/parity-file/src/main/java/com/paritytrading/parity/file/taq/TAQWriter.java
@@ -15,12 +15,20 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.FieldPosition;
+import java.text.NumberFormat;
 import java.util.Locale;
 
 /**
  * A writer.
  */
 public class TAQWriter implements Closeable, Flushable {
+
+    private static final DecimalFormatSymbols SYMBOLS = DecimalFormatSymbols.getInstance(Locale.US);
+
+    private static final int BUFFER_CAPACITY = 32;
 
     private static final String HEADER = "" +
         "Date"        + FIELD_SEPARATOR +
@@ -34,6 +42,12 @@ public class TAQWriter implements Closeable, Flushable {
         "Trade Price" + FIELD_SEPARATOR +
         "Trade Size"  + FIELD_SEPARATOR +
         "Trade Side"  + RECORD_SEPARATOR;
+
+    private DecimalFormat priceFormat;
+
+    private FieldPosition position;
+
+    private StringBuffer buffer;
 
     private PrintWriter sink;
 
@@ -69,6 +83,12 @@ public class TAQWriter implements Closeable, Flushable {
     }
 
     private TAQWriter(Writer writer) {
+        priceFormat = new DecimalFormat("0.00", SYMBOLS);
+
+        position = new FieldPosition(NumberFormat.INTEGER_FIELD);
+
+        buffer = new StringBuffer(BUFFER_CAPACITY);
+
         sink = new PrintWriter(writer);
 
         sink.print(HEADER);
@@ -160,7 +180,11 @@ public class TAQWriter implements Closeable, Flushable {
     }
 
     private void writePrice(double price) {
-        sink.printf(Locale.US, "%4.2f", price);
+        buffer.setLength(0);
+
+        priceFormat.format(price, buffer, position);
+
+        sink.append(buffer);
     }
 
 }

--- a/parity-file/src/main/java/com/paritytrading/parity/file/taq/TAQWriter.java
+++ b/parity-file/src/main/java/com/paritytrading/parity/file/taq/TAQWriter.java
@@ -44,6 +44,7 @@ public class TAQWriter implements Closeable, Flushable {
         "Trade Side"  + RECORD_SEPARATOR;
 
     private DecimalFormat priceFormat;
+    private DecimalFormat sizeFormat;
 
     private FieldPosition position;
 
@@ -84,6 +85,7 @@ public class TAQWriter implements Closeable, Flushable {
 
     private TAQWriter(Writer writer) {
         priceFormat = new DecimalFormat("0.00", SYMBOLS);
+        sizeFormat  = new DecimalFormat("0", SYMBOLS);
 
         position = new FieldPosition(NumberFormat.INTEGER_FIELD);
 
@@ -118,7 +120,7 @@ public class TAQWriter implements Closeable, Flushable {
         sink.print(FIELD_SEPARATOR);
         writePrice(record.price);
         sink.print(FIELD_SEPARATOR);
-        sink.print(record.size);
+        writeSize(record.size);
         sink.print(FIELD_SEPARATOR);
 
         if (record.side != UNKNOWN)
@@ -148,7 +150,7 @@ public class TAQWriter implements Closeable, Flushable {
         sink.print(FIELD_SEPARATOR);
 
         if (record.bidSize > 0)
-            sink.print(record.bidSize);
+            writeSize(record.bidSize);
 
         sink.print(FIELD_SEPARATOR);
 
@@ -158,7 +160,7 @@ public class TAQWriter implements Closeable, Flushable {
         sink.print(FIELD_SEPARATOR);
 
         if (record.askSize > 0)
-            sink.print(record.askSize);
+            writeSize(record.askSize);
 
         sink.print(FIELD_SEPARATOR);
         // trade price
@@ -183,6 +185,14 @@ public class TAQWriter implements Closeable, Flushable {
         buffer.setLength(0);
 
         priceFormat.format(price, buffer, position);
+
+        sink.append(buffer);
+    }
+
+    private void writeSize(double size) {
+        buffer.setLength(0);
+
+        sizeFormat.format(size, buffer, position);
 
         sink.append(buffer);
     }

--- a/parity-file/src/test/java/com/paritytrading/parity/file/taq/TAQWriterTest.java
+++ b/parity-file/src/test/java/com/paritytrading/parity/file/taq/TAQWriterTest.java
@@ -8,9 +8,7 @@ import org.junit.Test;
 public class TAQWriterTest {
 
     @Test
-    public void write() throws Exception {
-	ByteArrayOutputStream out = new ByteArrayOutputStream();
-
+    public void writeWithDefaultConfiguration() throws Exception {
 	TAQ.Quote quote = new TAQ.Quote();
 
 	quote.date            = "2016-01-01";
@@ -21,19 +19,11 @@ public class TAQWriterTest {
 	quote.askPrice        = 100.75;
 	quote.askSize         = 250;
 
-	TAQ.Trade trade = new TAQ.Trade();
-
-	trade.date            = "2016-01-01";
-	trade.timestampMillis = 8 * 60 * 60 * 1000 + 5 * 1000;
-	trade.instrument      = "FOO";
-	trade.price           = 100.75;
-	trade.size            = 100;
-	trade.side            = TAQ.SELL;
+	ByteArrayOutputStream out = new ByteArrayOutputStream();
 
 	TAQWriter writer = new TAQWriter(out);
 
 	writer.write(quote);
-	writer.write(trade);
 	writer.flush();
 
 	String output = "" +
@@ -58,7 +48,46 @@ public class TAQWriterTest {
 	    "250\t" +
 	    "\t" +
 	    "\t" +
-	    "\n" +
+	    "\n";
+
+	assertEquals(output, out.toString("US-ASCII"));
+    }
+
+    @Test
+    public void writeWithCustomConfiguration() throws Exception {
+	TAQ.Trade trade = new TAQ.Trade();
+
+	trade.date            = "2016-01-01";
+	trade.timestampMillis = 8 * 60 * 60 * 1000 + 5 * 1000;
+	trade.instrument      = "FOO";
+	trade.price           = 0.975000;
+	trade.size            = 0.00000100;
+	trade.side            = TAQ.SELL;
+
+	ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+	TAQConfig config = new TAQConfig.Builder()
+	    .setPriceFractionDigits(6)
+	    .setSizeFractionDigits(8)
+	    .build();
+
+	TAQWriter writer = new TAQWriter(out, config);
+
+	writer.write(trade);
+	writer.flush();
+
+	String output = "" +
+	    "Date\t" +
+	    "Timestamp\t" +
+	    "Instrument\t" +
+	    "Record Type\t" +
+	    "Bid Price\t" +
+	    "Bid Size\t" +
+	    "Ask Price\t" +
+	    "Ask Size\t" +
+	    "Trade Price\t" +
+	    "Trade Size\t" +
+	    "Trade Side\n" +
 	    "2016-01-01\t" +
 	    "08:00:05.000\t" +
 	    "FOO\t" +
@@ -67,8 +96,8 @@ public class TAQWriterTest {
 	    "\t" +
 	    "\t" +
 	    "\t" +
-	    "100.75\t" +
-	    "100\t" +
+	    "0.975000\t" +
+	    "0.00000100\t" +
 	    "S\n";
 
 	assertEquals(output, out.toString("US-ASCII"));

--- a/parity-ticker/src/main/java/com/paritytrading/parity/ticker/TAQFormat.java
+++ b/parity-ticker/src/main/java/com/paritytrading/parity/ticker/TAQFormat.java
@@ -7,6 +7,7 @@ import com.paritytrading.foundation.ASCII;
 import com.paritytrading.parity.book.OrderBook;
 import com.paritytrading.parity.book.Side;
 import com.paritytrading.parity.file.taq.TAQ;
+import com.paritytrading.parity.file.taq.TAQConfig;
 import com.paritytrading.parity.file.taq.TAQWriter;
 import it.unimi.dsi.fastutil.longs.Long2ObjectArrayMap;
 import java.nio.charset.Charset;
@@ -32,7 +33,11 @@ class TAQFormat extends MarketDataListener {
         quote.date = date;
         trade.date = date;
 
-        writer = new TAQWriter(System.out, Charset.defaultCharset());
+        TAQConfig config = new TAQConfig.Builder()
+            .setEncoding(Charset.defaultCharset())
+            .build();
+
+        writer = new TAQWriter(System.out, config);
         writer.flush();
     }
 


### PR DESCRIPTION
Make it possible to configure the number of digits in the fractional part of a price or a size in the TAQ file format.