### PR TITLE
Fix pending cancel status handling in FIX gateway

### DIFF
--- a/parity-fix/src/main/java/com/paritytrading/parity/fix/Order.java
+++ b/parity-fix/src/main/java/com/paritytrading/parity/fix/Order.java
@@ -8,6 +8,7 @@ class Order {
 
     private String orderEntryId;
     private long   orderId;
+    private String nextClOrdId;
     private String clOrdId;
     private String origClOrdId;
     private char   ordStatus;
@@ -22,6 +23,7 @@ class Order {
             String symbol, long orderQty) {
         this.orderEntryId = orderEntryId;
         this.orderId      = 0;
+        this.nextClOrdId  = null;
         this.clOrdId      = clOrdId;
         this.origClOrdId  = null;
         this.ordStatus    = OrdStatusValues.New;
@@ -47,6 +49,12 @@ class Order {
 
     public void orderCanceled(long canceledQuantity) {
         orderQty -= canceledQuantity;
+
+        origClOrdId = clOrdId;
+
+        clOrdId = nextClOrdId;
+
+        nextClOrdId = null;
     }
 
     public String getOrderEntryID() {
@@ -61,14 +69,16 @@ class Order {
         return clOrdId;
     }
 
-    public void setClOrdID(String clOrdId) {
-        this.origClOrdId = this.clOrdId;
-
-        this.clOrdId = clOrdId;
-    }
-
     public String getOrigClOrdID() {
         return origClOrdId;
+    }
+
+    public void setNextClOrdID(String nextClOrdId) {
+        this.nextClOrdId = nextClOrdId;
+    }
+
+    public String getNextClOrdID() {
+        return nextClOrdId;
     }
 
     public char getOrdStatus() {
@@ -101,6 +111,10 @@ class Order {
 
     public double getAvgPx() {
         return avgPx;
+    }
+
+    public boolean isInPendingStatus() {
+        return nextClOrdId != null;
     }
 
 }

--- a/parity-fix/src/main/java/com/paritytrading/parity/fix/Orders.java
+++ b/parity-fix/src/main/java/com/paritytrading/parity/fix/Orders.java
@@ -26,17 +26,6 @@ class Orders {
         return null;
     }
 
-    public Order findByOrigClOrdID(String origClOrdId) {
-        for (int i = 0; i < orders.size(); i++) {
-            Order order = orders.get(i);
-
-            if (origClOrdId.equals(order.getOrigClOrdID()))
-                return order;
-        }
-
-        return null;
-    }
-
     public Order findByOrderEntryID(String orderEntryId) {
         for (int i = 0; i < orders.size(); i++) {
             Order order = orders.get(i);


### PR DESCRIPTION
When an Order Cancel Request or Order Cancel/Replace Request message is received, the FIX gateway updates ClOrdID(11) and OrigClOrdID(41) and sends an Execution Report message with an ExecType(150) value of 6 (Pending cancel) or E (Pending replace). Updating ClOrdID(11) and OrigClOrdID(41) at this point is an error, because fills should be still reported using the original ClOrdID(11) value until the FIX gateway sends an Execution Report message with an ExecType(150) value of 4 (Canceled) or 5 (Replace). This message is triggered by an Order Canceled message from the trading system.