### PR TITLE
Fix pending cancel status handling in FIX gateway

### DIFF
--- a/parity-fix/doc/FIX.md
+++ b/parity-fix/doc/FIX.md
@@ -333,6 +333,7 @@ The reasons for order cancel rejection are enumerated below.
 
 CxlRejReason(102) | Description
 ------------------|----------------------------------------------------------
+0                 | Too late to cancel
 1                 | Unknown order
 3                 | Order already in Pending Cancel or Pending Replace status
 6                 | Duplicate ClOrdID(11)

--- a/parity-fix/src/main/java/com/paritytrading/parity/fix/Order.java
+++ b/parity-fix/src/main/java/com/paritytrading/parity/fix/Order.java
@@ -19,21 +19,23 @@ class Order {
     private long   orderQty;
     private long   cumQty;
     private double avgPx;
+    private char   cxlRejResponseTo;
 
     public Order(String orderEntryId, String clOrdId, String account, char side,
             String symbol, long orderQty) {
-        this.orderEntryId = new byte[POE.ORDER_ID_LENGTH];
-        this.orderId      = 0;
-        this.nextClOrdId  = null;
-        this.clOrdId      = clOrdId;
-        this.origClOrdId  = null;
-        this.ordStatus    = OrdStatusValues.New;
-        this.account      = null;
-        this.side         = side;
-        this.symbol       = symbol;
-        this.orderQty     = orderQty;
-        this.cumQty       = 0;
-        this.avgPx        = 0.0;
+        this.orderEntryId     = new byte[POE.ORDER_ID_LENGTH];
+        this.orderId          = 0;
+        this.nextClOrdId      = null;
+        this.clOrdId          = clOrdId;
+        this.origClOrdId      = null;
+        this.ordStatus        = OrdStatusValues.New;
+        this.account          = null;
+        this.side             = side;
+        this.symbol           = symbol;
+        this.orderQty         = orderQty;
+        this.cumQty           = 0;
+        this.avgPx            = 0.0;
+        this.cxlRejResponseTo = CxlRejResponseToValues.OrderCancelRequest;
 
         ASCII.putLeft(this.orderEntryId, orderEntryId);
     }
@@ -114,6 +116,14 @@ class Order {
 
     public double getAvgPx() {
         return avgPx;
+    }
+
+    public void setCxlRejResponseTo(char cxlRejResponseTo) {
+        this.cxlRejResponseTo = cxlRejResponseTo;
+    }
+
+    public char getCxlRejResponseTo() {
+        return cxlRejResponseTo;
     }
 
     public boolean isInPendingStatus() {


### PR DESCRIPTION
If the FIX gateway receives an Order Executed message indicating that an order has been executed fully while awaiting for an Order Canceled message indicating that the order has been canceled in part or fully, it must generate an Order Cancel Reject message with an CxlRejReason(102) value of 0 (Too late to cancel). Implement this.