### PR TITLE
Remove Broken Trade message

### DIFF
--- a/applications/client/src/main/java/com/paritytrading/parity/client/event/DefaultEventVisitor.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/event/DefaultEventVisitor.java
@@ -18,8 +18,4 @@ class DefaultEventVisitor implements EventVisitor {
     public void visit(Event.OrderCanceled event) {
     }
 
-    @Override
-    public void visit(Event.BrokenTrade event) {
-    }
-
 }

--- a/applications/client/src/main/java/com/paritytrading/parity/client/event/Event.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/event/Event.java
@@ -91,23 +91,4 @@ public interface Event {
         }
     }
 
-    class BrokenTrade implements Event {
-        public final long   timestamp;
-        public final String orderId;
-        public final long   matchNumber;
-        public final byte   reason;
-
-        public BrokenTrade(POE.BrokenTrade message) {
-            this.timestamp   = message.timestamp;
-            this.orderId     = ASCII.get(message.orderId);
-            this.matchNumber = message.matchNumber;
-            this.reason      = message.reason;
-        }
-
-        @Override
-        public void accept(EventVisitor visitor) {
-            visitor.visit(this);
-        }
-    }
-
 }

--- a/applications/client/src/main/java/com/paritytrading/parity/client/event/EventVisitor.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/event/EventVisitor.java
@@ -10,6 +10,4 @@ public interface EventVisitor {
 
     void visit(Event.OrderCanceled event);
 
-    void visit(Event.BrokenTrade event);
-
 }

--- a/applications/client/src/main/java/com/paritytrading/parity/client/event/Events.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/event/Events.java
@@ -38,11 +38,6 @@ public class Events implements POEClientListener {
         add(new Event.OrderCanceled(message));
     }
 
-    @Override
-    public void brokenTrade(POE.BrokenTrade message) {
-        add(new Event.BrokenTrade(message));
-    }
-
     private void add(Event event) {
         events = events.newWith(event);
     }

--- a/applications/client/src/main/java/com/paritytrading/parity/client/event/Trades.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/event/Trades.java
@@ -44,9 +44,4 @@ public class Trades extends DefaultEventVisitor {
         trades.put(event.matchNumber, new Trade(order, event));
     }
 
-    @Override
-    public void visit(Event.BrokenTrade event) {
-        trades.removeAll(event.matchNumber);
-    }
-
 }

--- a/applications/fix/src/main/java/com/paritytrading/parity/fix/Session.java
+++ b/applications/fix/src/main/java/com/paritytrading/parity/fix/Session.java
@@ -672,10 +672,6 @@ class Session implements Closeable {
         }
 
         @Override
-        public void brokenTrade(POE.BrokenTrade message) {
-        }
-
-        @Override
         public void heartbeatTimeout(SoupBinTCPClient session) throws IOException {
             fix.sendLogout("Trading system not available");
         }

--- a/applications/ticker/src/main/java/com/paritytrading/parity/ticker/MarketDataProcessor.java
+++ b/applications/ticker/src/main/java/com/paritytrading/parity/ticker/MarketDataProcessor.java
@@ -57,10 +57,6 @@ class MarketDataProcessor implements PMDListener {
         market.delete(message.orderNumber);
     }
 
-    @Override
-    public void brokenTrade(PMD.BrokenTrade message) {
-    }
-
     private Side side(byte side) {
         return side == PMD.BUY ? Side.BUY : Side.SELL;
     }

--- a/libraries/net/doc/PMD.md
+++ b/libraries/net/doc/PMD.md
@@ -106,16 +106,6 @@ Message Type |      1 | Text   | `D`
 Timestamp    |      4 | Number |
 Order Number |      8 | Number |
 
-### Broken Trade
-
-A Broken Trade message indicates that a trade has been rendered void.
-
-Name         | Length | Type   | Notes
--------------|--------|--------|------
-Message Type |      1 | Text   | `B`
-Timestamp    |      4 | Number |
-Match Number |      4 | Number |
-
 ## History
 
 - **Version 1.** Initial version.

--- a/libraries/net/doc/POE.md
+++ b/libraries/net/doc/POE.md
@@ -151,25 +151,6 @@ Reason | Description
 `R`    | Request
 `S`    | Supervisory
 
-### Broken Trade
-
-A Broken Trade message indicates that a trade has been rendered void.
-
-Name         | Length | Type   | Notes
--------------|--------|--------|----------
-Message Type |      1 | Text   | `B`
-Timestamp    |      8 | Number |
-Order ID     |     16 | Text   |
-Match Number |      4 | Number |
-Reason       |      1 | Text   | See below
-
-The reasons for a break are enumerated below.
-
-Reason | Description
--------|------------
-`C`    | Consent
-`S`    | Supervisory
-
 ## History
 
 - **Version 1.** Initial version.

--- a/libraries/net/src/main/java/com/paritytrading/parity/net/pmd/PMD.java
+++ b/libraries/net/src/main/java/com/paritytrading/parity/net/pmd/PMD.java
@@ -24,7 +24,6 @@ public class PMD {
     static final byte MESSAGE_TYPE_ORDER_EXECUTED = 'E';
     static final byte MESSAGE_TYPE_ORDER_CANCELED = 'X';
     static final byte MESSAGE_TYPE_ORDER_DELETED  = 'D';
-    static final byte MESSAGE_TYPE_BROKEN_TRADE   = 'B';
 
     /**
      * A message.
@@ -170,27 +169,6 @@ public class PMD {
             buffer.put(MESSAGE_TYPE_ORDER_DELETED);
             putUnsignedInt(buffer, timestamp);
             buffer.putLong(orderNumber);
-        }
-    }
-
-    /**
-     * A Broken Trade message.
-     */
-    public static class BrokenTrade implements Message {
-        public long timestamp;
-        public long matchNumber;
-
-        @Override
-        public void get(ByteBuffer buffer) {
-            timestamp   = getUnsignedInt(buffer);
-            matchNumber = getUnsignedInt(buffer);
-        }
-
-        @Override
-        public void put(ByteBuffer buffer) {
-            buffer.put(MESSAGE_TYPE_BROKEN_TRADE);
-            putUnsignedInt(buffer, timestamp);
-            putUnsignedInt(buffer, matchNumber);
         }
     }
 

--- a/libraries/net/src/main/java/com/paritytrading/parity/net/pmd/PMDListener.java
+++ b/libraries/net/src/main/java/com/paritytrading/parity/net/pmd/PMDListener.java
@@ -57,12 +57,4 @@ public interface PMDListener {
      */
     void orderDeleted(OrderDeleted message) throws IOException;
 
-    /**
-     * Receive a Broken Trade message.
-     *
-     * @param message the message
-     * @throws IOException if an I/O error occurs
-     */
-    void brokenTrade(BrokenTrade message) throws IOException;
-
 }

--- a/libraries/net/src/main/java/com/paritytrading/parity/net/pmd/PMDParser.java
+++ b/libraries/net/src/main/java/com/paritytrading/parity/net/pmd/PMDParser.java
@@ -17,7 +17,6 @@ public class PMDParser implements MessageListener {
     private OrderExecuted orderExecuted;
     private OrderCanceled orderCanceled;
     private OrderDeleted  orderDeleted;
-    private BrokenTrade   brokenTrade;
 
     private PMDListener listener;
 
@@ -33,7 +32,6 @@ public class PMDParser implements MessageListener {
         this.orderExecuted = new OrderExecuted();
         this.orderCanceled = new OrderCanceled();
         this.orderDeleted  = new OrderDeleted();
-        this.brokenTrade   = new BrokenTrade();
 
         this.listener = listener;
     }
@@ -66,10 +64,6 @@ public class PMDParser implements MessageListener {
         case MESSAGE_TYPE_ORDER_DELETED:
             orderDeleted.get(buffer);
             listener.orderDeleted(orderDeleted);
-            break;
-        case MESSAGE_TYPE_BROKEN_TRADE:
-            brokenTrade.get(buffer);
-            listener.brokenTrade(brokenTrade);
             break;
         default:
             throw new PMDException("Unknown message type: " + (char)messageType);

--- a/libraries/net/src/main/java/com/paritytrading/parity/net/poe/POE.java
+++ b/libraries/net/src/main/java/com/paritytrading/parity/net/poe/POE.java
@@ -29,9 +29,6 @@ public class POE {
     public static final byte ORDER_CANCEL_REASON_REQUEST     = 'R';
     public static final byte ORDER_CANCEL_REASON_SUPERVISORY = 'S';
 
-    public static final byte BROKEN_TRADE_REASON_CONSENT     = 'C';
-    public static final byte BROKEN_TRADE_REASON_SUPERVISORY = 'S';
-
     public static final byte ORDER_ID_LENGTH = 16;
 
     /**
@@ -124,7 +121,7 @@ public class POE {
     static final byte MESSAGE_TYPE_ORDER_REJECTED = 'R';
     static final byte MESSAGE_TYPE_ORDER_EXECUTED = 'E';
     static final byte MESSAGE_TYPE_ORDER_CANCELED = 'X';
-    static final byte MESSAGE_TYPE_BROKEN_TRADE   = 'B';
+
 
     /**
      * An Order Accepted message.
@@ -270,40 +267,6 @@ public class POE {
             buffer.putLong(timestamp);
             buffer.put(orderId);
             putUnsignedInt(buffer, canceledQuantity);
-            buffer.put(reason);
-        }
-    }
-
-    /**
-     * A Broken Trade message.
-     */
-    public static class BrokenTrade implements OutboundMessage {
-        public long   timestamp;
-        public byte[] orderId;
-        public long   matchNumber;
-        public byte   reason;
-
-        /**
-         * Create an instance.
-         */
-        public BrokenTrade() {
-            orderId = new byte[ORDER_ID_LENGTH];
-        }
-
-        @Override
-        public void get(ByteBuffer buffer) {
-            timestamp   = buffer.getLong();
-            buffer.get(orderId);
-            matchNumber = getUnsignedInt(buffer);
-            reason      = buffer.get();
-        }
-
-        @Override
-        public void put(ByteBuffer buffer) {
-            buffer.put(MESSAGE_TYPE_BROKEN_TRADE);
-            buffer.putLong(timestamp);
-            buffer.put(orderId);
-            putUnsignedInt(buffer, matchNumber);
             buffer.put(reason);
         }
     }

--- a/libraries/net/src/main/java/com/paritytrading/parity/net/poe/POEClientListener.java
+++ b/libraries/net/src/main/java/com/paritytrading/parity/net/poe/POEClientListener.java
@@ -41,12 +41,4 @@ public interface POEClientListener {
      */
     void orderCanceled(OrderCanceled message) throws IOException;
 
-    /**
-     * Receive a Broken Trade message.
-     *
-     * @param message the message
-     * @throws IOException if an I/O error occurs
-     */
-    void brokenTrade(BrokenTrade message) throws IOException;
-
 }

--- a/libraries/net/src/main/java/com/paritytrading/parity/net/poe/POEClientParser.java
+++ b/libraries/net/src/main/java/com/paritytrading/parity/net/poe/POEClientParser.java
@@ -15,7 +15,6 @@ public class POEClientParser implements MessageListener {
     private OrderRejected orderRejected;
     private OrderExecuted orderExecuted;
     private OrderCanceled orderCanceled;
-    private BrokenTrade   brokenTrade;
 
     private POEClientListener listener;
 
@@ -29,7 +28,6 @@ public class POEClientParser implements MessageListener {
         this.orderRejected = new OrderRejected();
         this.orderExecuted = new OrderExecuted();
         this.orderCanceled = new OrderCanceled();
-        this.brokenTrade   = new BrokenTrade();
 
         this.listener = listener;
     }
@@ -54,10 +52,6 @@ public class POEClientParser implements MessageListener {
         case MESSAGE_TYPE_ORDER_CANCELED:
             orderCanceled.get(buffer);
             listener.orderCanceled(orderCanceled);
-            break;
-        case MESSAGE_TYPE_BROKEN_TRADE:
-            brokenTrade.get(buffer);
-            listener.brokenTrade(brokenTrade);
             break;
         default:
             throw new POEException("Unknown message type: " + (char)messageType);


### PR DESCRIPTION
As the implementation of #40 results in changes in the network protocols, now is a good opportunity to remove the Broken Trade message as well.