### PR TITLE
Make price and size format configurable per instrument

### DIFF
--- a/applications/client/README.md
+++ b/applications/client/README.md
@@ -33,13 +33,14 @@ You can interact with the application by entering commands into the command
 prompt. For example, to enter a buy order, use the `buy` command:
 
 ```
-> buy 100 FOO 10.00
+> buy 100 AAPL 150.00
 ```
 
-The command enters a buy order of 100 units of the instrument FOO at the limit
-price of 10.00 into the trading system. Assuming that FOO can be traded on the
-trading system and that there is no matching sell order in the order book, the
-order will remain open. To list the open orders, use the `orders` command:
+The command enters a buy order of 100 units of the instrument AAPL at the
+limit price of 150.00 into the trading system. Assuming that AAPL can be
+traded on the trading system and that there is no matching sell order in
+the order book, the order will remain open. To list the open orders, use
+the `orders` command:
 
 ```
 > orders
@@ -79,7 +80,7 @@ instruments {
     # The number of digits in the integer part of a size.
     size-integer-digits = 4
 
-    FOO {
+    AAPL {
 
         # The number of digits in the fractional part of a price.
         price-fraction-digits = 2

--- a/applications/client/README.md
+++ b/applications/client/README.md
@@ -70,6 +70,26 @@ order-entry {
     password = parity
 
 }
+
+instruments {
+
+    # The number of digits in the integer part of a price.
+    price-integer-digits = 4
+
+    # The number of digits in the integer part of a size.
+    size-integer-digits = 4
+
+    FOO {
+
+        # The number of digits in the fractional part of a price.
+        price-fraction-digits = 2
+
+        # The number of digits in the fractional part of a size.
+        size-fraction-digits = 0
+
+    }
+
+}
 ```
 
 See the `etc` directory for an example configuration file.

--- a/applications/client/etc/example.conf
+++ b/applications/client/etc/example.conf
@@ -9,7 +9,7 @@ instruments {
   price-integer-digits = 4
   size-integer-digits  = 4
 
-  FOO {
+  AAPL {
     price-fraction-digits = 2
     size-fraction-digits  = 0
   }

--- a/applications/client/etc/example.conf
+++ b/applications/client/etc/example.conf
@@ -4,3 +4,21 @@ order-entry {
   username = parity
   password = parity
 }
+
+instruments {
+  price-integer-digits = 4
+  size-integer-digits  = 4
+
+  FOO {
+    price-fraction-digits = 2
+    size-fraction-digits  = 0
+  }
+  BAR {
+    price-fraction-digits = 2
+    size-fraction-digits  = 8
+  }
+  BAZ {
+    price-fraction-digits = 6
+    size-fraction-digits  = 8
+  }
+}

--- a/applications/client/etc/example.conf
+++ b/applications/client/etc/example.conf
@@ -7,7 +7,7 @@ order-entry {
 
 instruments {
   price-integer-digits = 4
-  size-integer-digits  = 4
+  size-integer-digits  = 7
 
   AAPL {
     price-fraction-digits = 2

--- a/applications/client/etc/example.conf
+++ b/applications/client/etc/example.conf
@@ -17,8 +17,8 @@ instruments {
     price-fraction-digits = 6
     size-fraction-digits  = 3
   }
-  BAZ {
-    price-fraction-digits = 6
-    size-fraction-digits  = 8
+  EUR-USD {
+    price-fraction-digits = 5
+    size-fraction-digits  = 0
   }
 }

--- a/applications/client/etc/example.conf
+++ b/applications/client/etc/example.conf
@@ -13,9 +13,9 @@ instruments {
     price-fraction-digits = 2
     size-fraction-digits  = 0
   }
-  BAR {
-    price-fraction-digits = 2
-    size-fraction-digits  = 8
+  ETH-BTC {
+    price-fraction-digits = 6
+    size-fraction-digits  = 3
   }
   BAZ {
     price-fraction-digits = 6

--- a/applications/client/src/main/java/com/paritytrading/parity/client/command/EnterCommand.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/command/EnterCommand.java
@@ -5,6 +5,8 @@ import static com.paritytrading.parity.client.TerminalClient.*;
 import com.paritytrading.foundation.ASCII;
 import com.paritytrading.parity.client.TerminalClient;
 import com.paritytrading.parity.net.poe.POE;
+import com.paritytrading.parity.util.Instrument;
+import com.paritytrading.parity.util.Instruments;
 import java.io.IOException;
 import java.util.NoSuchElementException;
 import java.util.Scanner;
@@ -22,14 +24,18 @@ class EnterCommand implements Command {
     @Override
     public void execute(TerminalClient client, Scanner arguments) throws CommandException, IOException {
         try {
-            long quantity   = arguments.nextInt();
-            long instrument = ASCII.packLong(arguments.next());
-            long price      = (long)(arguments.nextDouble() * PRICE_FACTOR);
+            double quantity   = arguments.nextDouble();
+            long   instrument = ASCII.packLong(arguments.next());
+            double price      = arguments.nextDouble();
 
             if (arguments.hasNext())
                 throw new CommandException();
 
-            execute(client, quantity, instrument, price);
+            Instrument config = client.getInstruments().get(instrument);
+            if (config == null)
+                throw new CommandException();
+
+            execute(client, (long)(quantity * config.getSizeFactor()), instrument, (long)(price * config.getPriceFactor()));
         } catch (NoSuchElementException e) {
             throw new CommandException();
         }

--- a/applications/client/src/main/java/com/paritytrading/parity/client/command/OrdersCommand.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/command/OrdersCommand.java
@@ -3,6 +3,8 @@ package com.paritytrading.parity.client.command;
 import com.paritytrading.parity.client.TerminalClient;
 import com.paritytrading.parity.client.event.Order;
 import com.paritytrading.parity.client.event.Orders;
+import com.paritytrading.parity.util.Instruments;
+import com.paritytrading.parity.util.TableHeader;
 import java.util.Scanner;
 
 class OrdersCommand implements Command {
@@ -12,9 +14,25 @@ class OrdersCommand implements Command {
         if (arguments.hasNext())
             throw new CommandException();
 
-        client.printf("\n%s\n", Order.HEADER);
+        Instruments instruments = client.getInstruments();
+
+        int priceWidth = instruments.getPriceWidth();
+        int sizeWidth  = instruments.getSizeWidth();
+
+        TableHeader header = new TableHeader();
+
+        header.add("Timestamp",       12);
+        header.add("Order ID",        16);
+        header.add("S",                1);
+        header.add("Inst",             8);
+        header.add("Quantity", sizeWidth);
+        header.add("Price",   priceWidth);
+
+        client.printf("\n");
+        client.printf(header.format());
+
         for (Order order : Orders.collect(client.getEvents()))
-            client.printf("%s\n", order.format());
+            client.printf("%s\n", order.format(client.getInstruments()));
         client.printf("\n");
     }
 

--- a/applications/client/src/main/java/com/paritytrading/parity/client/command/TradesCommand.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/command/TradesCommand.java
@@ -3,6 +3,8 @@ package com.paritytrading.parity.client.command;
 import com.paritytrading.parity.client.TerminalClient;
 import com.paritytrading.parity.client.event.Trade;
 import com.paritytrading.parity.client.event.Trades;
+import com.paritytrading.parity.util.Instruments;
+import com.paritytrading.parity.util.TableHeader;
 import java.util.Scanner;
 
 class TradesCommand implements Command {
@@ -12,9 +14,25 @@ class TradesCommand implements Command {
         if (arguments.hasNext())
             throw new CommandException();
 
-        client.printf("\n%s\n", Trade.HEADER);
+        Instruments instruments = client.getInstruments();
+
+        int priceWidth = instruments.getPriceWidth();
+        int sizeWidth  = instruments.getSizeWidth();
+
+        TableHeader header = new TableHeader();
+
+        header.add("Timestamp",       12);
+        header.add("Order ID",        16);
+        header.add("S",                1);
+        header.add("Inst",             8);
+        header.add("Quantity", sizeWidth);
+        header.add("Price",   priceWidth);
+
+        client.printf("\n");
+        client.printf(header.format());
+
         for (Trade trade : Trades.collect(client.getEvents()))
-            client.printf("%s\n", trade.format());
+            client.printf("%s\n", trade.format(client.getInstruments()));
         client.printf("\n");
     }
 

--- a/applications/client/src/main/java/com/paritytrading/parity/client/event/Order.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/event/Order.java
@@ -3,13 +3,11 @@ package com.paritytrading.parity.client.event;
 import static com.paritytrading.parity.client.TerminalClient.*;
 
 import com.paritytrading.foundation.ASCII;
+import com.paritytrading.parity.util.Instrument;
+import com.paritytrading.parity.util.Instruments;
 import com.paritytrading.parity.util.Timestamps;
 
 public class Order {
-
-    public static final String HEADER = "" +
-            "Timestamp    Order ID         S Inst     Quantity   Price\n" +
-            "------------ ---------------- - -------- ---------- ---------";
 
     private long   timestamp;
     private String orderId;
@@ -57,10 +55,18 @@ public class Order {
         return quantity;
     }
 
-    public String format() {
-        return String.format(LOCALE, "%12s %16s %c %8s %10d %9.2f",
+    public String format(Instruments instruments) {
+        Instrument config = instruments.get(instrument);
+
+        String priceFormat = config.getPriceFormat();
+        String sizeFormat  = config.getSizeFormat();
+
+        String format = "%12s %16s %c %8s " + sizeFormat + " " + priceFormat;
+
+        return String.format(LOCALE, format,
                 Timestamps.format(timestamp / NANOS_PER_MILLI), orderId, side,
-                ASCII.unpackLong(instrument), quantity, price / PRICE_FACTOR);
+                ASCII.unpackLong(instrument), quantity / config.getSizeFactor(),
+                price / config.getPriceFactor());
     }
 
 }

--- a/applications/client/src/main/java/com/paritytrading/parity/client/event/Trade.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/event/Trade.java
@@ -3,13 +3,11 @@ package com.paritytrading.parity.client.event;
 import static com.paritytrading.parity.client.TerminalClient.*;
 
 import com.paritytrading.foundation.ASCII;
+import com.paritytrading.parity.util.Instrument;
+import com.paritytrading.parity.util.Instruments;
 import com.paritytrading.parity.util.Timestamps;
 
 public class Trade {
-
-    public static final String HEADER = "" +
-            "Timestamp    Order ID         S Inst     Quantity   Price\n" +
-            "------------ ---------------- - -------- ---------- ---------";
 
     private long  timestamp;
     private Order order;
@@ -27,10 +25,18 @@ public class Trade {
         return timestamp;
     }
 
-    public String format() {
-        return String.format(LOCALE, "%12s %16s %c %8s %10d %9.2f",
+    public String format(Instruments instruments) {
+        Instrument config = instruments.get(order.getInstrument());
+
+        String priceFormat = config.getPriceFormat();
+        String sizeFormat  = config.getSizeFormat();
+
+        String format = "%12s %16s %c %8s " + sizeFormat + " " + priceFormat;
+
+        return String.format(LOCALE, format,
                 Timestamps.format(timestamp / NANOS_PER_MILLI), order.getOrderId(), order.getSide(),
-                ASCII.unpackLong(order.getInstrument()), quantity, price / PRICE_FACTOR);
+                ASCII.unpackLong(order.getInstrument()), quantity / config.getSizeFactor(),
+                price / config.getPriceFactor());
     }
 
 }

--- a/applications/fix/README.md
+++ b/applications/fix/README.md
@@ -61,6 +61,20 @@ order-entry {
     port = 4000
 
 }
+
+instruments {
+
+    FOO {
+
+        # The number of digits in the fractional part of a price.
+        price-fraction-digits = 2
+
+        # The number of digits in the fractional part of a size.
+        size-fraction-digits = 0
+
+    }
+
+}
 ```
 
 See the `etc` directory for an example configuration file.

--- a/applications/fix/README.md
+++ b/applications/fix/README.md
@@ -64,7 +64,7 @@ order-entry {
 
 instruments {
 
-    FOO {
+    AAPL {
 
         # The number of digits in the fractional part of a price.
         price-fraction-digits = 2

--- a/applications/fix/doc/FIX.md
+++ b/applications/fix/doc/FIX.md
@@ -20,8 +20,6 @@ messages.
 
 ClOrdID(11) has a maximum length of 16 characters.
 
-Price(44) has two decimal places.
-
 ### Message Header
 
 All messages start with the message header.

--- a/applications/fix/etc/example.conf
+++ b/applications/fix/etc/example.conf
@@ -18,8 +18,8 @@ instruments {
     price-fraction-digits = 6
     size-fraction-digits  = 3
   }
-  BAZ {
-    price-fraction-digits = 6
-    size-fraction-digits  = 8
+  EUR-USD {
+    price-fraction-digits = 5
+    size-fraction-digits  = 0
   }
 }

--- a/applications/fix/etc/example.conf
+++ b/applications/fix/etc/example.conf
@@ -8,3 +8,18 @@ order-entry {
   address = 127.0.0.1
   port    = 4000
 }
+
+instruments {
+  FOO {
+    price-fraction-digits = 2
+    size-fraction-digits  = 0
+  }
+  BAR {
+    price-fraction-digits = 2
+    size-fraction-digits  = 8
+  }
+  BAZ {
+    price-fraction-digits = 6
+    size-fraction-digits  = 8
+  }
+}

--- a/applications/fix/etc/example.conf
+++ b/applications/fix/etc/example.conf
@@ -14,9 +14,9 @@ instruments {
     price-fraction-digits = 2
     size-fraction-digits  = 0
   }
-  BAR {
-    price-fraction-digits = 2
-    size-fraction-digits  = 8
+  ETH-BTC {
+    price-fraction-digits = 6
+    size-fraction-digits  = 3
   }
   BAZ {
     price-fraction-digits = 6

--- a/applications/fix/etc/example.conf
+++ b/applications/fix/etc/example.conf
@@ -10,7 +10,7 @@ order-entry {
 }
 
 instruments {
-  FOO {
+  AAPL {
     price-fraction-digits = 2
     size-fraction-digits  = 0
   }

--- a/applications/fix/src/main/java/com/paritytrading/parity/fix/FIXAcceptor.java
+++ b/applications/fix/src/main/java/com/paritytrading/parity/fix/FIXAcceptor.java
@@ -2,6 +2,7 @@ package com.paritytrading.parity.fix;
 
 import java.io.IOException;
 
+import com.paritytrading.parity.util.Instruments;
 import com.paritytrading.philadelphia.FIXConfig;
 import com.paritytrading.philadelphia.FIXVersion;
 import java.net.InetSocketAddress;
@@ -17,8 +18,11 @@ class FIXAcceptor {
 
     private FIXConfig config;
 
-    private FIXAcceptor(OrderEntryFactory orderEntry, ServerSocketChannel serverChannel,
-            String senderCompId) {
+    private Instruments instruments;
+
+    private FIXAcceptor(OrderEntryFactory orderEntry,
+            ServerSocketChannel serverChannel, String senderCompId,
+            Instruments instruments) {
         this.orderEntry = orderEntry;
 
         this.serverChannel = serverChannel;
@@ -27,16 +31,19 @@ class FIXAcceptor {
             .setVersion(FIXVersion.FIX_4_4)
             .setSenderCompID(senderCompId)
             .build();
+
+        this.instruments = instruments;
     }
 
     public static FIXAcceptor open(OrderEntryFactory orderEntry,
-            InetSocketAddress address, String senderCompId) throws IOException {
+            InetSocketAddress address, String senderCompId,
+            Instruments instruments) throws IOException {
         ServerSocketChannel serverChannel = ServerSocketChannel.open();
 
         serverChannel.bind(address);
         serverChannel.configureBlocking(false);
 
-        return new FIXAcceptor(orderEntry, serverChannel, senderCompId);
+        return new FIXAcceptor(orderEntry, serverChannel, senderCompId, instruments);
     }
 
     public ServerSocketChannel getServerChannel() {
@@ -53,7 +60,7 @@ class FIXAcceptor {
                 fix.setOption(StandardSocketOptions.TCP_NODELAY, true);
                 fix.configureBlocking(false);
 
-                return new Session(orderEntry, fix, config);
+                return new Session(orderEntry, fix, config, instruments);
             } catch (IOException e1) {
                 fix.close();
 

--- a/applications/fix/src/main/java/com/paritytrading/parity/fix/FIXGateway.java
+++ b/applications/fix/src/main/java/com/paritytrading/parity/fix/FIXGateway.java
@@ -2,6 +2,7 @@ package com.paritytrading.parity.fix;
 
 import static org.jvirtanen.util.Applications.*;
 
+import com.paritytrading.parity.util.Instruments;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
 import java.io.FileNotFoundException;
@@ -44,7 +45,10 @@ class FIXGateway {
         int         port         = Configs.getPort(config, "fix.port");
         String      senderCompId = config.getString("fix.sender-comp-id");
 
-        return FIXAcceptor.open(orderEntry, new InetSocketAddress(address, port), senderCompId);
+        Instruments instruments = Instruments.fromConfig(config, "instruments");
+
+        return FIXAcceptor.open(orderEntry, new InetSocketAddress(address, port),
+                senderCompId, instruments);
     }
 
 }

--- a/applications/fix/src/main/java/com/paritytrading/parity/fix/Order.java
+++ b/applications/fix/src/main/java/com/paritytrading/parity/fix/Order.java
@@ -16,13 +16,13 @@ class Order {
     private String account;
     private char   side;
     private String symbol;
-    private long   orderQty;
-    private long   cumQty;
+    private double orderQty;
+    private double cumQty;
     private double avgPx;
     private char   cxlRejResponseTo;
 
     public Order(String orderEntryId, String clOrdId, String account, char side,
-            String symbol, long orderQty) {
+            String symbol, double orderQty) {
         this.orderEntryId     = new byte[POE.ORDER_ID_LENGTH];
         this.orderId          = 0;
         this.nextClOrdId      = null;
@@ -44,7 +44,7 @@ class Order {
         orderId = orderNumber;
     }
 
-    public void orderExecuted(long quantity, double price) {
+    public void orderExecuted(double quantity, double price) {
         avgPx = (cumQty * avgPx + quantity * price) / (cumQty + quantity);
 
         cumQty += quantity;
@@ -52,7 +52,7 @@ class Order {
         ordStatus = getLeavesQty() == 0 ? OrdStatusValues.Filled : OrdStatusValues.PartiallyFilled;
     }
 
-    public void orderCanceled(long canceledQuantity) {
+    public void orderCanceled(double canceledQuantity) {
         orderQty -= canceledQuantity;
 
         origClOrdId = clOrdId;
@@ -102,15 +102,15 @@ class Order {
         return symbol;
     }
 
-    public long getOrderQty() {
+    public double getOrderQty() {
         return orderQty;
     }
 
-    public long getCumQty() {
+    public double getCumQty() {
         return cumQty;
     }
 
-    public long getLeavesQty() {
+    public double getLeavesQty() {
         return orderQty - cumQty;
     }
 

--- a/applications/fix/test/test.txt
+++ b/applications/fix/test/test.txt
@@ -31,14 +31,14 @@ send 35=A|98=0|108=30|553=foo|554=bar
 #
 #   MsgType(35)      = D
 #   ClOrdID(11)      = 1
-#   Symbol(55)       = FOO
+#   Symbol(55)       = AAPL
 #   Side(54)         = 1 (Buy)
 #   TransactTime(60) = <skipped>
 #   OrderQty(38)     = 100
 #   OrdType(40)      = 2 (Limit)
-#   Price(44)        = 10.00
+#   Price(44)        = 150.00
 #
-send 35=D|11=1|55=FOO|54=1|38=100|40=2|44=10.00
+send 35=D|11=1|55=AAPL|54=1|38=100|40=2|44=150.00
 
 #
 # Expect: Execution Report
@@ -49,14 +49,14 @@ send 35=D|11=1|55=FOO|54=1|38=100|40=2|44=10.00
 #   ExecID(17)     = <generated>
 #   ExecType(150)  = 0 (New)
 #   OrdStatus(39)  = 0 (New)
-#   Symbol(55)     = FOO
+#   Symbol(55)     = AAPL
 #   Side(54)       = 1 (Buy)
 #   OrderQty(38)   = 100
 #   LeavesQty(151) = 100
 #   CumQty(14)     = 0
 #   AvgPx(6)       = 0.00
 #
-# 35=8|37=...|11=1|17=...|150=0|39=0|55=FOO|54=1|38=100|151=100|14=0|6=0.00
+# 35=8|37=...|11=1|17=...|150=0|39=0|55=AAPL|54=1|38=100|151=100|14=0|6=0.00
 #
 
 #
@@ -82,14 +82,14 @@ send 35=G|11=2|41=1|54=1|38=50|40=2
 #   ExecID(17)      = <generated>
 #   ExecType(150)   = E (Pending replace)
 #   OrdStatus(39)   = E (Pending replace)
-#   Symbol(55)      = FOO
+#   Symbol(55)      = AAPL
 #   Side(54)        = 1 (Buy)
 #   OrderQty(38)    = 100
 #   LeavesQty(151)  = 100
 #   CumQty(14)      = 0
 #   AvgPx(6)        = 0.00
 #
-# 35=8|37=...|11=2|41=1|17=...|150=E|39=E|55=FOO|38=100|151=100|14=0|6=0.00
+# 35=8|37=...|11=2|41=1|17=...|150=E|39=E|55=AAPL|38=100|151=100|14=0|6=0.00
 #
 
 #
@@ -102,14 +102,14 @@ send 35=G|11=2|41=1|54=1|38=50|40=2
 #   ExecID(17)      = <generated>
 #   ExecType(150)   = 5 (Replace)
 #   OrdStatus(39)   = 0 (New)
-#   Symbol(55)      = FOO
+#   Symbol(55)      = AAPL
 #   Side(54)        = 1 (Buy)
 #   OrderQty(38)    = 50
 #   LeavesQty(151)  = 50
 #   CumQty(14)      = 0
 #   AvgPx(6)        = 0.00
 #
-# 35=8|37=...|11=2|41=1|17=...|150=4|39=4|55=FOO|38=50|151=50|14=0|6=0.00
+# 35=8|37=...|11=2|41=1|17=...|150=4|39=4|55=AAPL|38=50|151=50|14=0|6=0.00
 #
 
 #
@@ -133,14 +133,14 @@ send 35=F|11=3|41=2|54=1
 #   ExecID(17)      = <generated>
 #   ExecType(150)   = 6 (Pending cancel)
 #   OrdStatus(39)   = 6 (Pending cancel)
-#   Symbol(55)      = FOO
+#   Symbol(55)      = AAPL
 #   Side(54)        = 1 (Buy)
 #   OrderQty(38)    = 50
 #   LeavesQty(151)  = 50
 #   CumQty(14)      = 0
 #   AvgPx(6)        = 0.00
 #
-# 35=8|37=...|11=3|41=2|17=...|150=6|39=6|55=FOO|38=50|151=50|14=0|6=0.00
+# 35=8|37=...|11=3|41=2|17=...|150=6|39=6|55=AAPL|38=50|151=50|14=0|6=0.00
 #
 
 #
@@ -153,14 +153,14 @@ send 35=F|11=3|41=2|54=1
 #   ExecID(17)      = <generated>
 #   ExecType(150)   = 4 (Canceled)
 #   OrdStatus(39)   = 4 (Canceled)
-#   Symbol(55)      = FOO
+#   Symbol(55)      = AAPL
 #   Side(54)        = 1 (Buy)
 #   OrderQty(38)    = 50
 #   LeavesQty(151)  = 0
 #   CumQty(14)      = 0
 #   AvgPx(6)        = 0.00
 #
-# 35=8|37=...|11=3|41=2|17=...|150=4|39=4|55=FOO|38=50|151=0|14=0|6=0.00
+# 35=8|37=...|11=3|41=2|17=...|150=4|39=4|55=AAPL|38=50|151=0|14=0|6=0.00
 #
 
 #

--- a/applications/reporter/README.md
+++ b/applications/reporter/README.md
@@ -24,16 +24,16 @@ The command line options are as follows:
 The command line arguments are as follows:
 
 - `<configuration-file>`: The configuration file. The configuration file
-  specifies how to connect to the the trading system.
+  specifies how to display instruments and connect to the the trading system.
 
 Once started, the application first replays trades that have taken place so
 far. Then it proceeds to display trades in real time.
 
 ## Configuration
 
-Parity Trade Reporter uses a configuration file to specify how to connect to
-the trading system. It supports two transport options: NASDAQ MoldUDP64 and
-NASDAQ SoupBinTCP.
+Parity Trade Reporter uses a configuration file to specify how to display
+instruments and connect to the trading system. The application supports two
+transport options: NASDAQ MoldUDP64 and NASDAQ SoupBinTCP.
 
 The following configuration parameters are required when using the MoldUDP64
 transport:
@@ -76,6 +76,30 @@ trade-report {
 
     # The SoupBinTCP password.
     password = parity
+
+}
+```
+
+The following configuration parameters are required always:
+
+```
+instruments {
+
+    # The number of digits in the integer part of a price.
+    price-integer-digits = 4
+
+    # The number of digits in the integer part of a size.
+    size-integer-digits = 4
+
+    FOO {
+
+        # The number of digits in the fractional part of a price.
+        price-fraction-digits = 2
+
+        # The number of digits in the fractional part of a size.
+        size-fraction-digits = 0
+
+    }
 
 }
 ```

--- a/applications/reporter/README.md
+++ b/applications/reporter/README.md
@@ -91,7 +91,7 @@ instruments {
     # The number of digits in the integer part of a size.
     size-integer-digits = 4
 
-    FOO {
+    AAPL {
 
         # The number of digits in the fractional part of a price.
         price-fraction-digits = 2

--- a/applications/reporter/etc/example-tcp.conf
+++ b/applications/reporter/etc/example-tcp.conf
@@ -21,8 +21,8 @@ instruments {
     price-fraction-digits = 6
     size-fraction-digits  = 3
   }
-  BAZ {
-    price-fraction-digits = 6
-    size-fraction-digits  = 8
+  EUR-USD {
+    price-fraction-digits = 5
+    size-fraction-digits  = 0
   }
 }

--- a/applications/reporter/etc/example-tcp.conf
+++ b/applications/reporter/etc/example-tcp.conf
@@ -8,3 +8,21 @@ trade-report {
   username = parity
   password = parity
 }
+
+instruments {
+  price-integer-digits = 4
+  size-integer-digits  = 4
+
+  FOO {
+    price-fraction-digits = 2
+    size-fraction-digits  = 0
+  }
+  BAR {
+    price-fraction-digits = 2
+    size-fraction-digits  = 8
+  }
+  BAZ {
+    price-fraction-digits = 6
+    size-fraction-digits  = 8
+  }
+}

--- a/applications/reporter/etc/example-tcp.conf
+++ b/applications/reporter/etc/example-tcp.conf
@@ -13,7 +13,7 @@ instruments {
   price-integer-digits = 4
   size-integer-digits  = 4
 
-  FOO {
+  AAPL {
     price-fraction-digits = 2
     size-fraction-digits  = 0
   }

--- a/applications/reporter/etc/example-tcp.conf
+++ b/applications/reporter/etc/example-tcp.conf
@@ -11,7 +11,7 @@ trade-report {
 
 instruments {
   price-integer-digits = 4
-  size-integer-digits  = 4
+  size-integer-digits  = 7
 
   AAPL {
     price-fraction-digits = 2

--- a/applications/reporter/etc/example-tcp.conf
+++ b/applications/reporter/etc/example-tcp.conf
@@ -17,9 +17,9 @@ instruments {
     price-fraction-digits = 2
     size-fraction-digits  = 0
   }
-  BAR {
-    price-fraction-digits = 2
-    size-fraction-digits  = 8
+  ETH-BTC {
+    price-fraction-digits = 6
+    size-fraction-digits  = 3
   }
   BAZ {
     price-fraction-digits = 6

--- a/applications/reporter/etc/example-udp.conf
+++ b/applications/reporter/etc/example-udp.conf
@@ -14,7 +14,7 @@ instruments {
   price-integer-digits = 4
   size-integer-digits  = 4
 
-  FOO {
+  AAPL {
     price-fraction-digits = 2
     size-fraction-digits  = 0
   }

--- a/applications/reporter/etc/example-udp.conf
+++ b/applications/reporter/etc/example-udp.conf
@@ -22,8 +22,8 @@ instruments {
     price-fraction-digits = 6
     size-fraction-digits  = 3
   }
-  BAZ {
-    price-fraction-digits = 6
-    size-fraction-digits  = 8
+  EUR-USD {
+    price-fraction-digits = 5
+    size-fraction-digits  = 0
   }
 }

--- a/applications/reporter/etc/example-udp.conf
+++ b/applications/reporter/etc/example-udp.conf
@@ -12,7 +12,7 @@ trade-report {
 
 instruments {
   price-integer-digits = 4
-  size-integer-digits  = 4
+  size-integer-digits  = 7
 
   AAPL {
     price-fraction-digits = 2

--- a/applications/reporter/etc/example-udp.conf
+++ b/applications/reporter/etc/example-udp.conf
@@ -9,3 +9,21 @@ trade-report {
   request-address     = 127.0.0.1
   request-port        = 6001
 }
+
+instruments {
+  price-integer-digits = 4
+  size-integer-digits  = 4
+
+  FOO {
+    price-fraction-digits = 2
+    size-fraction-digits  = 0
+  }
+  BAR {
+    price-fraction-digits = 2
+    size-fraction-digits  = 8
+  }
+  BAZ {
+    price-fraction-digits = 6
+    size-fraction-digits  = 8
+  }
+}

--- a/applications/reporter/etc/example-udp.conf
+++ b/applications/reporter/etc/example-udp.conf
@@ -18,9 +18,9 @@ instruments {
     price-fraction-digits = 2
     size-fraction-digits  = 0
   }
-  BAR {
-    price-fraction-digits = 2
-    size-fraction-digits  = 8
+  ETH-BTC {
+    price-fraction-digits = 6
+    size-fraction-digits  = 3
   }
   BAZ {
     price-fraction-digits = 6

--- a/applications/reporter/src/main/java/com/paritytrading/parity/reporter/DisplayFormat.java
+++ b/applications/reporter/src/main/java/com/paritytrading/parity/reporter/DisplayFormat.java
@@ -1,20 +1,41 @@
 package com.paritytrading.parity.reporter;
 
+import com.paritytrading.parity.util.Instrument;
+import com.paritytrading.parity.util.Instruments;
+import com.paritytrading.parity.util.TableHeader;
+
 class DisplayFormat extends TradeListener {
 
-    private static final String HEADER = "" +
-        "Timestamp    Inst     Quantity   Price     Buyer    Seller\n" +
-        "------------ -------- ---------- --------- -------- --------";
+    private Instruments instruments;
 
-    public DisplayFormat() {
-        printf("\n%s\n", HEADER);
+    public DisplayFormat(Instruments instruments) {
+        this.instruments = instruments;
+
+        int priceWidth = instruments.getPriceWidth();
+        int sizeWidth  = instruments.getSizeWidth();
+
+        TableHeader header = new TableHeader();
+
+        header.add("Timestamp",       12);
+        header.add("Inst",             8);
+        header.add("Quantity", sizeWidth);
+        header.add("Price",   priceWidth);
+        header.add("Buyer",            8);
+        header.add("Seller",           8);
+
+        printf("\n");
+        printf(header.format());
     }
 
     @Override
     public void trade(Trade event) {
-        printf("%12s %-8s %10d %9.2f %-8s %-8s\n",
-                event.timestamp, event.instrument, event.quantity, event.price,
-                event.buyer, event.seller);
+        Instrument instrument = instruments.get(event.instrument);
+
+        printf("%12s %-8s ", event.timestamp, event.instrument);
+        printf(instrument.getSizeFormat(), event.quantity / instrument.getSizeFactor());
+        printf(" ");
+        printf(instrument.getPriceFormat(), event.price / instrument.getPriceFactor());
+        printf(" %-8s %-8s\n", event.buyer, event.seller);
     }
 
 }

--- a/applications/reporter/src/main/java/com/paritytrading/parity/reporter/TSVFormat.java
+++ b/applications/reporter/src/main/java/com/paritytrading/parity/reporter/TSVFormat.java
@@ -1,5 +1,10 @@
 package com.paritytrading.parity.reporter;
 
+import com.paritytrading.parity.util.Instrument;
+import com.paritytrading.parity.util.Instruments;
+import java.util.HashMap;
+import java.util.Map;
+
 class TSVFormat extends TradeListener {
 
     private static final String HEADER = "" +
@@ -13,15 +18,41 @@ class TSVFormat extends TradeListener {
         "Seller\t" +
         "Sell Order Number\n";
 
-    public TSVFormat() {
+    private Instruments instruments;
+
+    private Map<String, String> formats;
+
+    public TSVFormat(Instruments instruments) {
+        this.instruments = instruments;
+
+        this.formats = new HashMap<>();
+
+        for (Instrument instrument : instruments) {
+            int priceFractionDigits = instrument.getPriceFractionDigits();
+            int sizeFractionDigits  = instrument.getSizeFractionDigits();
+
+            String format = "%." + sizeFractionDigits + "f\t%." + priceFractionDigits + "f\t";
+
+            formats.put(instrument.asString(), format);
+        }
+
         printf(HEADER);
     }
 
     @Override
     public void trade(Trade event) {
-        printf("%s\t%d\t%s\t%d\t%.2f\t%s\t%d\t%s\t%d\n",
-                event.timestamp, event.matchNumber, event.instrument, event.quantity,
-                event.price, event.buyer, event.buyOrderNumber, event.seller,
+        printf("%s\t%d\t%s\t", event.timestamp, event.matchNumber, event.instrument);
+
+        Instrument instrument = instruments.get(event.instrument);
+
+        double priceFactor = instrument.getPriceFactor();
+        double sizeFactor  = instrument.getSizeFactor();
+
+        String format = formats.get(event.instrument);
+
+        printf(format, event.quantity / sizeFactor, event.price / priceFactor);
+
+        printf("%s\t%d\t%s\t%d\n", event.buyer, event.buyOrderNumber, event.seller,
                 event.sellOrderNumber);
     }
 

--- a/applications/reporter/src/main/java/com/paritytrading/parity/reporter/Trade.java
+++ b/applications/reporter/src/main/java/com/paritytrading/parity/reporter/Trade.java
@@ -6,7 +6,7 @@ class Trade {
     public long   matchNumber;
     public String instrument;
     public long   quantity;
-    public double price;
+    public long   price;
     public String buyer;
     public long   buyOrderNumber;
     public String seller;

--- a/applications/reporter/src/main/java/com/paritytrading/parity/reporter/TradeProcessor.java
+++ b/applications/reporter/src/main/java/com/paritytrading/parity/reporter/TradeProcessor.java
@@ -68,7 +68,7 @@ class TradeProcessor implements PMRListener {
         trade.matchNumber     = message.matchNumber;
         trade.instrument      = ASCII.unpackLong(resting.instrument).trim();
         trade.quantity        = message.quantity;
-        trade.price           = resting.price / 100.0;
+        trade.price           = resting.price;
         trade.buyer           = ASCII.unpackLong(buy.username).trim();
         trade.buyOrderNumber  = buyOrderNumber;
         trade.seller          = ASCII.unpackLong(sell.username).trim();

--- a/applications/reporter/src/main/java/com/paritytrading/parity/reporter/TradeReporter.java
+++ b/applications/reporter/src/main/java/com/paritytrading/parity/reporter/TradeReporter.java
@@ -6,6 +6,7 @@ import com.paritytrading.nassau.MessageListener;
 import com.paritytrading.nassau.util.MoldUDP64;
 import com.paritytrading.nassau.util.SoupBinTCP;
 import com.paritytrading.parity.net.pmr.PMRParser;
+import com.paritytrading.parity.util.Instruments;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
 import java.io.FileNotFoundException;
@@ -42,7 +43,10 @@ class TradeReporter {
     }
 
     private static void main(Config config, boolean tsv) throws IOException {
-        MessageListener listener = new PMRParser(new TradeProcessor(tsv ? new TSVFormat() : new DisplayFormat()));
+        Instruments instruments = Instruments.fromConfig(config, "instruments");
+
+        MessageListener listener = new PMRParser(new TradeProcessor(tsv ?
+                    new TSVFormat(instruments) : new DisplayFormat(instruments)));
 
         if (config.hasPath("trade-report.multicast-interface")) {
             NetworkInterface multicastInterface = Configs.getNetworkInterface(config, "trade-report.multicast-interface");

--- a/applications/system/README.md
+++ b/applications/system/README.md
@@ -89,7 +89,7 @@ order-entry {
 }
 
 # A list of zero or more instruments.
-instruments = [ AAPL, BAR, BAZ ]
+instruments = [ AAPL, ETH-BTC, BAZ ]
 ```
 
 See the `etc` directory for an example configuration file.

--- a/applications/system/README.md
+++ b/applications/system/README.md
@@ -89,7 +89,7 @@ order-entry {
 }
 
 # A list of zero or more instruments.
-instruments = [ AAPL, ETH-BTC, BAZ ]
+instruments = [ AAPL, ETH-BTC, EUR-USD ]
 ```
 
 See the `etc` directory for an example configuration file.

--- a/applications/system/README.md
+++ b/applications/system/README.md
@@ -89,7 +89,7 @@ order-entry {
 }
 
 # A list of zero or more instruments.
-instruments = [ FOO, BAR, BAZ ]
+instruments = [ AAPL, BAR, BAZ ]
 ```
 
 See the `etc` directory for an example configuration file.

--- a/applications/system/etc/example.conf
+++ b/applications/system/etc/example.conf
@@ -23,6 +23,6 @@ order-entry {
 
 instruments = [
   AAPL,
-  BAR,
+  ETH-BTC,
   BAZ,
 ]

--- a/applications/system/etc/example.conf
+++ b/applications/system/etc/example.conf
@@ -24,5 +24,5 @@ order-entry {
 instruments = [
   AAPL,
   ETH-BTC,
-  BAZ,
+  EUR-USD,
 ]

--- a/applications/system/etc/example.conf
+++ b/applications/system/etc/example.conf
@@ -22,7 +22,7 @@ order-entry {
 }
 
 instruments = [
-  FOO,
+  AAPL,
   BAR,
   BAZ,
 ]

--- a/applications/ticker/README.md
+++ b/applications/ticker/README.md
@@ -14,17 +14,11 @@ Download the [latest release][] from GitHub.
 Run Parity Stock Ticker with Java:
 
 ```
-java -jar parity-ticker.jar
+java -jar parity-ticker.jar [-t] <configuration-file> [<input-file>]
 ```
 
 The application can either listen to a live market data feed or to read a
 historical market data file.
-
-To listen to a live market data feed, pass a configuration file:
-
-```
-java -jar parity-ticker.jar [-t] <configuration-file>
-```
 
 The command line options are as follows:
 
@@ -35,37 +29,24 @@ The command line options are as follows:
 The command line arguments are as follows:
 
 - `<configuration-file>`: The configuration file. The configuration file
-  specifies how to connect to the trading system.
+  specifies how to display instruments. When listening to live market data,
+  it also specifies how to connect to the trading system.
+
+- `<input-file>`: The input file. The application reads market events from
+  the input file in the NASDAQ BinaryFILE format.
 
 When listening to a live market data feed, the application first replays
 market events that have taken place so far. Then it proceeds to display
 market events in real time.
 
-To read a historical market data file, pass an input file:
-
-```
-java -jar parity-ticker.jar [-t] <input-file> [<instrument> ...]
-```
-
-The command line options are as follows:
-
-- `-t`: Format the output as [TAQ][].
-
-The command line arguments are as follows:
-
-- `<input-file>`: The input file. The application reads market events from
-  the input file in the NASDAQ BinaryFILE format.
-
-- `[<instrument> ...]`: Zero or more instruments.
-
 ## Configuration
 
-Parity Stock Ticker uses a configuration file to specify how to connect to the
-trading system. It supports two transport options: NASDAQ MoldUDP64 and NASDAQ
-SoupBinTCP.
+Parity Stock Ticker uses a configuration file to specify how to display
+instruments and connect to the trading system. The application supports two
+transport options: NASDAQ MoldUDP64 and NASDAQ SoupBinTCP.
 
-The following configuration parameters are required when using the MoldUDP64
-transport:
+The following configuration parameters are required when connecting to the
+trading system using the MoldUDP64 transport:
 
 ```
 market-data {
@@ -86,13 +67,10 @@ market-data {
     request-port = 5001
 
 }
-
-# A list of zero or more instruments.
-instruments = [ FOO, BAR, BAZ ]
 ```
 
-The following configuration parameters are required when using the SoupBinTCP
-transport:
+The following configuration parameters are required when connecting to the
+trading system using the SoupBinTCP transport:
 
 ```
 market-data {
@@ -110,9 +88,30 @@ market-data {
     password = parity
 
 }
+```
 
-# A list of zero or more instruments.
-instruments = [ FOO, BAR, BAZ ]
+The following configuration parameters are required always:
+
+```
+instruments {
+
+    # The number of digits in the integer part of a price.
+    price-integer-digits = 4
+
+    # The number of digits in the integer part of a size.
+    size-integer-digits = 4
+
+    FOO {
+
+        # The number of digits in the fractional part of a price.
+        price-fraction-digits = 2
+
+        # The number of digits in the fractional part of a size.
+        size-fraction-digits = 0
+
+    }
+
+}
 ```
 
 See the `etc` directory for example configuration files.

--- a/applications/ticker/README.md
+++ b/applications/ticker/README.md
@@ -101,7 +101,7 @@ instruments {
     # The number of digits in the integer part of a size.
     size-integer-digits = 4
 
-    FOO {
+    AAPL {
 
         # The number of digits in the fractional part of a price.
         price-fraction-digits = 2

--- a/applications/ticker/etc/example-tcp.conf
+++ b/applications/ticker/etc/example-tcp.conf
@@ -21,8 +21,8 @@ instruments {
     price-fraction-digits = 6
     size-fraction-digits  = 3
   }
-  BAZ {
-    price-fraction-digits = 6
-    size-fraction-digits  = 8
+  EUR-USD {
+    price-fraction-digits = 5
+    size-fraction-digits  = 0
   }
 }

--- a/applications/ticker/etc/example-tcp.conf
+++ b/applications/ticker/etc/example-tcp.conf
@@ -11,7 +11,7 @@ market-data {
 
 instruments {
   price-integer-digits = 4
-  size-integer-digits  = 4
+  size-integer-digits  = 7
 
   AAPL {
     price-fraction-digits = 2

--- a/applications/ticker/etc/example-tcp.conf
+++ b/applications/ticker/etc/example-tcp.conf
@@ -13,7 +13,7 @@ instruments {
   price-integer-digits = 4
   size-integer-digits  = 4
 
-  FOO {
+  AAPL {
     price-fraction-digits = 2
     size-fraction-digits  = 0
   }

--- a/applications/ticker/etc/example-tcp.conf
+++ b/applications/ticker/etc/example-tcp.conf
@@ -9,8 +9,20 @@ market-data {
   password = parity
 }
 
-instruments = [
-  FOO,
-  BAR,
-  BAZ,
-]
+instruments {
+  price-integer-digits = 4
+  size-integer-digits  = 4
+
+  FOO {
+    price-fraction-digits = 2
+    size-fraction-digits  = 0
+  }
+  BAR {
+    price-fraction-digits = 2
+    size-fraction-digits  = 8
+  }
+  BAZ {
+    price-fraction-digits = 6
+    size-fraction-digits  = 8
+  }
+}

--- a/applications/ticker/etc/example-tcp.conf
+++ b/applications/ticker/etc/example-tcp.conf
@@ -17,9 +17,9 @@ instruments {
     price-fraction-digits = 2
     size-fraction-digits  = 0
   }
-  BAR {
-    price-fraction-digits = 2
-    size-fraction-digits  = 8
+  ETH-BTC {
+    price-fraction-digits = 6
+    size-fraction-digits  = 3
   }
   BAZ {
     price-fraction-digits = 6

--- a/applications/ticker/etc/example-udp.conf
+++ b/applications/ticker/etc/example-udp.conf
@@ -14,7 +14,7 @@ instruments {
   price-integer-digits = 4
   size-integer-digits  = 4
 
-  FOO {
+  AAPL {
     price-fraction-digits = 2
     size-fraction-digits  = 0
   }

--- a/applications/ticker/etc/example-udp.conf
+++ b/applications/ticker/etc/example-udp.conf
@@ -12,7 +12,7 @@ market-data {
 
 instruments {
   price-integer-digits = 4
-  size-integer-digits  = 4
+  size-integer-digits  = 7
 
   AAPL {
     price-fraction-digits = 2

--- a/applications/ticker/etc/example-udp.conf
+++ b/applications/ticker/etc/example-udp.conf
@@ -10,8 +10,20 @@ market-data {
   request-port        = 5001
 }
 
-instruments = [
-  FOO,
-  BAR,
-  BAZ,
-]
+instruments {
+  price-integer-digits = 4
+  size-integer-digits  = 4
+
+  FOO {
+    price-fraction-digits = 2
+    size-fraction-digits  = 0
+  }
+  BAR {
+    price-fraction-digits = 2
+    size-fraction-digits  = 8
+  }
+  BAZ {
+    price-fraction-digits = 6
+    size-fraction-digits  = 8
+  }
+}

--- a/applications/ticker/etc/example-udp.conf
+++ b/applications/ticker/etc/example-udp.conf
@@ -22,8 +22,8 @@ instruments {
     price-fraction-digits = 6
     size-fraction-digits  = 3
   }
-  BAZ {
-    price-fraction-digits = 6
-    size-fraction-digits  = 8
+  EUR-USD {
+    price-fraction-digits = 5
+    size-fraction-digits  = 0
   }
 }

--- a/applications/ticker/etc/example-udp.conf
+++ b/applications/ticker/etc/example-udp.conf
@@ -18,9 +18,9 @@ instruments {
     price-fraction-digits = 2
     size-fraction-digits  = 0
   }
-  BAR {
-    price-fraction-digits = 2
-    size-fraction-digits  = 8
+  ETH-BTC {
+    price-fraction-digits = 6
+    size-fraction-digits  = 3
   }
   BAZ {
     price-fraction-digits = 6

--- a/applications/ticker/src/main/java/com/paritytrading/parity/ticker/MarketDataListener.java
+++ b/applications/ticker/src/main/java/com/paritytrading/parity/ticker/MarketDataListener.java
@@ -4,8 +4,6 @@ import com.paritytrading.parity.book.MarketListener;
 
 abstract class MarketDataListener implements MarketListener {
 
-    static final double PRICE_FACTOR = 100.0;
-
     private long timestamp;
 
     public void timestamp(long timestamp) {

--- a/libraries/util/pom.xml
+++ b/libraries/util/pom.xml
@@ -16,6 +16,18 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.paritytrading.foundation</groupId>
+      <artifactId>foundation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/libraries/util/src/main/java/com/paritytrading/parity/util/Instrument.java
+++ b/libraries/util/src/main/java/com/paritytrading/parity/util/Instrument.java
@@ -1,0 +1,136 @@
+package com.paritytrading.parity.util;
+
+import static com.paritytrading.foundation.Longs.*;
+import static com.paritytrading.parity.util.Strings.*;
+
+import com.paritytrading.foundation.ASCII;
+import com.typesafe.config.Config;
+import java.util.Arrays;
+
+/**
+ * An instrument configuration.
+ */
+public class Instrument {
+
+    private String asString;
+    private long   asLong;
+
+    private int priceFractionDigits;
+    private int sizeFractionDigits;
+
+    private long priceFactor;
+    private long sizeFactor;
+
+    private String priceFormat;
+    private String sizeFormat;
+
+    private Instrument(String asString, int priceFractionDigits, int sizeFractionDigits) {
+        this.asString = asString;
+        this.asLong   = ASCII.packLong(asString);
+
+        this.priceFractionDigits = priceFractionDigits;
+        this.sizeFractionDigits  = sizeFractionDigits;
+
+        this.priceFactor = POWERS_OF_TEN[priceFractionDigits];
+        this.sizeFactor  = POWERS_OF_TEN[sizeFractionDigits];
+
+        setPriceFormat(1, priceFractionDigits);
+        setSizeFormat(1, sizeFractionDigits);
+    }
+
+    /**
+     * Get this instrument as a string.
+     *
+     * @return this instrument as a string
+     */
+    public String asString() {
+        return asString;
+    }
+
+    /**
+     * Get this instrument as a long integer.
+     *
+     * @return this instrument as a long integer
+     */
+    public long asLong() {
+        return asLong;
+    }
+
+    /**
+     * Get the number of digits in the fractional part of a price.
+     *
+     * @return the number of digits in the fractional part of a price
+     */
+    public int getPriceFractionDigits() {
+        return priceFractionDigits;
+    }
+
+    /**
+     * Get the number of digits in the fractional part of a size.
+     *
+     * @return the number of digits in the fractional part of a size
+     */
+    public int getSizeFractionDigits() {
+        return sizeFractionDigits;
+    }
+
+    /**
+     * Get the multiplication factor for a price.
+     *
+     * @return the multiplication factor for a price
+     */
+    public double getPriceFactor() {
+        return priceFactor;
+    }
+
+    /**
+     * Get the multiplication factor for a size.
+     *
+     * @return the multiplication factor for a size
+     */
+    public double getSizeFactor() {
+        return sizeFactor;
+    }
+
+    /**
+     * Get a format string for a price.
+     *
+     * @return a format string for a price
+     */
+    public String getPriceFormat() {
+        return priceFormat;
+    }
+
+    /**
+     * Get a format string for a size.
+     *
+     * @return a format string for a size
+     */
+    public String getSizeFormat() {
+        return sizeFormat;
+    }
+
+    void setPriceFormat(int integerDigits, int maxFractionDigits) {
+        priceFormat = getFormat(integerDigits, priceFractionDigits, maxFractionDigits);
+    }
+
+    void setSizeFormat(int integerDigits, int maxFractionDigits) {
+        sizeFormat = getFormat(integerDigits, sizeFractionDigits, maxFractionDigits);
+    }
+
+    static Instrument fromConfig(Config config, String path) {
+        int priceFractionDigits = config.getInt(path + ".price-fraction-digits");
+        int sizeFractionDigits  = config.getInt(path + ".size-fraction-digits");
+
+        return new Instrument(path, priceFractionDigits, sizeFractionDigits);
+    }
+
+    private static String getFormat(int integerDigits, int fractionDigits, int maxFractionDigits) {
+        int width = integerDigits + (fractionDigits > 0 ? 1 : 0) + fractionDigits;
+
+        int padding = maxFractionDigits - fractionDigits + (fractionDigits == 0 ? 1 : 0);
+
+        return "%" + width + "." + fractionDigits + "f" + repeat(' ', padding);
+    }
+
+}

--- a/libraries/util/src/main/java/com/paritytrading/parity/util/Instruments.java
+++ b/libraries/util/src/main/java/com/paritytrading/parity/util/Instruments.java
@@ -1,0 +1,191 @@
+package com.paritytrading.parity.util;
+
+import static com.paritytrading.parity.util.Strings.*;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigObject;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.ToIntFunction;
+
+/**
+ * The instruments configuration.
+ */
+public class Instruments implements Iterable<Instrument> {
+
+    private HashMap<String, Instrument> valuesByString;
+
+    private Long2ObjectOpenHashMap<Instrument> valuesByLong;
+
+    private int maxPriceFractionDigits;
+    private int maxSizeFractionDigits;
+
+    private int priceWidth;
+    private int sizeWidth;
+
+    private String pricePlaceholder;
+    private String sizePlaceholder;
+
+    private Instruments(List<Instrument> values, int priceIntegerDigits, int maxPriceFractionDigits,
+            int sizeIntegerDigits, int maxSizeFractionDigits) {
+        this.valuesByString = new HashMap<>();
+        this.valuesByLong   = new Long2ObjectOpenHashMap<>();
+
+        for (Instrument value : values) {
+            valuesByString.put(value.asString(), value);
+            valuesByLong.put(value.asLong(), value);
+        }
+
+        this.maxPriceFractionDigits = maxPriceFractionDigits;
+        this.maxSizeFractionDigits  = maxSizeFractionDigits;
+
+        this.priceWidth = priceIntegerDigits + 1 + maxPriceFractionDigits;
+        this.sizeWidth  = sizeIntegerDigits  + 1 + maxSizeFractionDigits;
+
+        this.pricePlaceholder = placeholder(priceIntegerDigits, maxPriceFractionDigits);
+        this.sizePlaceholder  = placeholder(sizeIntegerDigits,  maxSizeFractionDigits);
+    }
+
+    /**
+     * Get an instrument.
+     *
+     * @param instrument an instrument
+     * @return the instrument
+     */
+    public Instrument get(String instrument) {
+        return valuesByString.get(instrument);
+    }
+
+    /**
+     * Get an instrument.
+     *
+     * @param instrument an instrument
+     * @return the instrument
+     */
+    public Instrument get(long instrument) {
+        return valuesByLong.get(instrument);
+    }
+
+    /**
+     * Return an iterator over the instruments.
+     *
+     * @return an iterator over the instruments
+     */
+    public Iterator<Instrument> iterator() {
+        return valuesByString.values().iterator();
+    }
+
+    /**
+     * Get the maximum number of digits in the fractional part of a price.
+     *
+     * @return the maximum number of digits in the fractional part of a price
+     */
+    public int getMaxPriceFractionDigits() {
+        return maxPriceFractionDigits;
+    }
+
+    /**
+     * Get the maximum number of digits in the fractional part of a size.
+     *
+     * @return the maximum number of digits in the fractional part of a size
+     */
+    public int getMaxSizeFractionDigits() {
+        return maxSizeFractionDigits;
+    }
+
+    /**
+     * Get the width of a formatted price.
+     *
+     * @return the width of a formatted price
+     */
+    public int getPriceWidth() {
+        return priceWidth;
+    }
+
+    /**
+     * Get the width of a formatted size.
+     *
+     * @return the width of a formatted size
+     */
+    public int getSizeWidth() {
+        return sizeWidth;
+    }
+
+    /**
+     * Get a placeholder for a price.
+     *
+     * @return a placeholder for a price
+     */
+    public String getPricePlaceholder() {
+        return pricePlaceholder;
+    }
+
+    /**
+     * Get a placeholder for a size.
+     *
+     * @return a placeholder for a size
+     */
+    public String getSizePlaceholder() {
+        return sizePlaceholder;
+    }
+
+    /**
+     * Get the instruments from a configuration object.
+     *
+     * @param config a configuration object
+     * @param path the path expression
+     * @return the instruments
+     * @throws ConfigException if a configuration error occurs
+     */
+    public static Instruments fromConfig(Config config, String path) {
+        ConfigObject root = config.getObject(path);
+
+        Config rootConfig = root.toConfig();
+
+        int priceIntegerDigits = getInt(rootConfig, "price-integer-digits", 1);
+        int sizeIntegerDigits  = getInt(rootConfig, "size-integer-digits",  1);
+
+        Set<String> instruments = root.keySet();
+
+        instruments.remove("price-integer-digits");
+        instruments.remove("size-integer-digits");
+
+        List<Instrument> values = new ArrayList<>();
+
+        for (String instrument : instruments)
+            values.add(Instrument.fromConfig(rootConfig, instrument));
+
+        int maxPriceFractionDigits = max(values, Instrument::getPriceFractionDigits);
+        int maxSizeFractionDigits  = max(values, Instrument::getSizeFractionDigits);
+
+        for (Instrument value : values) {
+            value.setPriceFormat(priceIntegerDigits, maxPriceFractionDigits);
+            value.setSizeFormat(sizeIntegerDigits, maxSizeFractionDigits);
+        }
+
+        return new Instruments(values, priceIntegerDigits, maxPriceFractionDigits,
+                sizeIntegerDigits, maxSizeFractionDigits);
+    }
+
+    private static int getInt(Config config, String path, int defaultValue) {
+        return config.hasPath(path) ? config.getInt(path) : defaultValue;
+    }
+
+    private static <T> int max(Collection<T> collection, ToIntFunction<? super T> mapper) {
+        return collection.stream().mapToInt(mapper).max().orElse(0);
+    }
+
+    private static String placeholder(int integerDigits, int maxFractionDigits) {
+        if (maxFractionDigits == 0)
+            return repeat(' ', integerDigits - 1) + '-';
+
+        return repeat(' ', integerDigits) + '-' + repeat(' ', maxFractionDigits);
+    }
+
+}

--- a/libraries/util/src/main/java/com/paritytrading/parity/util/Strings.java
+++ b/libraries/util/src/main/java/com/paritytrading/parity/util/Strings.java
@@ -1,0 +1,18 @@
+package com.paritytrading.parity.util;
+
+import java.util.Arrays;
+
+class Strings {
+
+    private Strings() {
+    }
+
+    public static String repeat(char c, int count) {
+        char[] a = new char[count];
+
+        Arrays.fill(a, c);
+
+        return new String(a);
+    }
+
+}

--- a/libraries/util/src/main/java/com/paritytrading/parity/util/TableHeader.java
+++ b/libraries/util/src/main/java/com/paritytrading/parity/util/TableHeader.java
@@ -1,0 +1,71 @@
+package com.paritytrading.parity.util;
+
+import static com.paritytrading.parity.util.Strings.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A table header.
+ */
+public class TableHeader {
+
+    private List<Column> columns;
+
+    /**
+     * Construct a new instance.
+     */
+    public TableHeader() {
+        columns = new ArrayList<>();
+    }
+
+    /**
+     * Add a column.
+     *
+     * @param name the column name
+     * @param width the column width
+     */
+    public void add(String name, int width) {
+        columns.add(new Column(name, width));
+    }
+
+    /**
+     * Format this table header for display.
+     *
+     * @return this table header formatted for display
+     */
+    public String format() {
+        StringBuilder builder = new StringBuilder();
+
+        for (int i = 0; i < columns.size(); i++) {
+            Column column = columns.get(i);
+
+            builder.append(format(column.name, column.width));
+            builder.append(i == columns.size() - 1 ? '\n' : ' ');
+        }
+
+        for (int i = 0; i < columns.size(); i++) {
+            Column column = columns.get(i);
+
+            builder.append(repeat('-', column.width));
+            builder.append(i == columns.size() - 1 ? '\n' : ' ');
+        }
+
+        return builder.toString();
+    }
+
+    private static class Column {
+        public String name;
+        public int    width;
+
+        public Column(String name, int width) {
+            this.name  = name;
+            this.width = width;
+        }
+    }
+
+    private static String format(String name, int width) {
+        return String.format("%-" + width + "." + width + "s", name);
+    }
+
+}

--- a/libraries/util/src/test/java/com/paritytrading/parity/util/InstrumentsTest.java
+++ b/libraries/util/src/test/java/com/paritytrading/parity/util/InstrumentsTest.java
@@ -1,0 +1,91 @@
+package com.paritytrading.parity.util;
+
+import static org.junit.Assert.*;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Test;
+
+public class InstrumentsTest {
+
+    private static final Instruments INSTRUMENTS = fromString("" +
+            "instruments = {\n" +
+            "  price-integer-digits = 4\n" +
+            "  size-integer-digits  = 8\n" +
+            "  FOO {\n" +
+            "    price-fraction-digits = 2\n" +
+            "    size-fraction-digits  = 0\n" +
+            "  }\n" +
+            "  BAR {\n" +
+            "    price-fraction-digits = 6\n" +
+            "    size-fraction-digits  = 8\n" +
+            "  }\n" +
+            "}");
+
+    @Test
+    public void maxPriceFractionDigits() {
+        assertEquals(6, INSTRUMENTS.getMaxPriceFractionDigits());
+    }
+
+    @Test
+    public void maxSizeFractionDigits() {
+        assertEquals(8, INSTRUMENTS.getMaxSizeFractionDigits());
+    }
+
+    @Test
+    public void pricePlaceholder() {
+        assertEquals("    -      ", INSTRUMENTS.getPricePlaceholder());
+    }
+
+    @Test
+    public void sizePlaceholder() {
+        assertEquals("        -        ", INSTRUMENTS.getSizePlaceholder());
+    }
+
+    @Test
+    public void priceWidth() {
+        assertEquals(11, INSTRUMENTS.getPriceWidth());
+    }
+
+    @Test
+    public void sizeWidth() {
+        assertEquals(17, INSTRUMENTS.getSizeWidth());
+    }
+
+    @Test
+    public void priceFractionDigits() {
+        assertEquals(2, INSTRUMENTS.get("FOO").getPriceFractionDigits());
+    }
+
+    @Test
+    public void sizeFractionDigits() {
+        assertEquals(0, INSTRUMENTS.get("FOO").getSizeFractionDigits());
+    }
+
+    @Test
+    public void priceFormat() {
+        assertEquals("%7.2f    ", INSTRUMENTS.get("FOO").getPriceFormat());
+    }
+
+    @Test
+    public void sizeFormat() {
+        assertEquals("%8.0f         ", INSTRUMENTS.get("FOO").getSizeFormat());
+    }
+
+    @Test
+    public void priceFactor() {
+        assertEquals(100.0, INSTRUMENTS.get("FOO").getPriceFactor(), 0.0);
+    }
+
+    @Test
+    public void sizeFactor() {
+        assertEquals(1.0, INSTRUMENTS.get("FOO").getSizeFactor(), 0.0);
+    }
+
+    private static Instruments fromString(String s) {
+        Config config = ConfigFactory.parseString(s);
+
+        return Instruments.fromConfig(config, "instruments");
+    }
+
+}

--- a/libraries/util/src/test/java/com/paritytrading/parity/util/TableHeaderTest.java
+++ b/libraries/util/src/test/java/com/paritytrading/parity/util/TableHeaderTest.java
@@ -1,0 +1,24 @@
+package com.paritytrading.parity.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TableHeaderTest {
+
+    @Test
+    public void foo() {
+        TableHeader actual = new TableHeader();
+
+        actual.add("Foo",  5);
+        actual.add("Bar",  5);
+        actual.add("Quux", 3);
+
+        String expected = ""
+            + "Foo   Bar   Quu\n"
+            + "----- ----- ---\n";
+
+        assertEquals(expected, actual.format());
+    }
+
+}


### PR DESCRIPTION
The trading system and the network protocols already operate in terms of the minimum price and quantity increment. However, until now the other applications have supported only one format for prices and sizes:

- Two digits in the fractional part of a price
- No digits in the fractional part of a size

Make price and size format configurable per instrument in these applications.