### PR TITLE
parity-match: Fix matching logic

### DIFF
--- a/libraries/match/src/main/java/com/paritytrading/parity/match/OrderBook.java
+++ b/libraries/match/src/main/java/com/paritytrading/parity/match/OrderBook.java
@@ -63,7 +63,7 @@ public class OrderBook {
         PriceLevel bestLevel = getBestLevel(asks);
 
         while (remainingQuantity > 0 && bestLevel != null && bestLevel.getPrice() <= price) {
-            remainingQuantity = bestLevel.match(orderId, Side.BUY, remainingQuantity, listener);
+            remainingQuantity = bestLevel.match(orderId, Side.BUY, remainingQuantity, orders, listener);
 
             if (bestLevel.isEmpty())
                 asks.remove(bestLevel.getPrice());
@@ -84,7 +84,7 @@ public class OrderBook {
         PriceLevel bestLevel = getBestLevel(bids);
 
         while (remainingQuantity > 0 && bestLevel != null && bestLevel.getPrice() >= price) {
-            remainingQuantity = bestLevel.match(orderId, Side.SELL, remainingQuantity, listener);
+            remainingQuantity = bestLevel.match(orderId, Side.SELL, remainingQuantity, orders, listener);
 
             if (bestLevel.isEmpty())
                 bids.remove(bestLevel.getPrice());

--- a/libraries/match/src/main/java/com/paritytrading/parity/match/PriceLevel.java
+++ b/libraries/match/src/main/java/com/paritytrading/parity/match/PriceLevel.java
@@ -1,5 +1,6 @@
 package com.paritytrading.parity.match;
 
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.ArrayList;
 
 class PriceLevel {
@@ -36,22 +37,26 @@ class PriceLevel {
         return order;
     }
 
-    public long match(long orderId, Side side, long quantity, OrderBookListener listener) {
+    public long match(long orderId, Side side, long quantity, Long2ObjectOpenHashMap<Order> orderIds, OrderBookListener listener) {
         while (quantity > 0 && !orders.isEmpty()) {
             Order resting = orders.get(0);
+
+            long restingId = resting.getId();
 
             long restingQuantity = resting.getRemainingQuantity();
 
             if (restingQuantity > quantity) {
                 resting.reduce(quantity);
 
-                listener.match(resting.getId(), orderId, side, price, quantity, resting.getRemainingQuantity());
+                listener.match(restingId, orderId, side, price, quantity, resting.getRemainingQuantity());
 
                 quantity = 0;
             } else {
                 orders.remove(0);
 
-                listener.match(resting.getId(), orderId, side, price, restingQuantity, 0);
+                orderIds.remove(restingId);
+
+                listener.match(restingId, orderId, side, price, restingQuantity, 0);
 
                 quantity -= restingQuantity;
             }

--- a/libraries/match/src/main/java/com/paritytrading/parity/match/PriceLevel.java
+++ b/libraries/match/src/main/java/com/paritytrading/parity/match/PriceLevel.java
@@ -38,22 +38,22 @@ class PriceLevel {
 
     public long match(long orderId, Side side, long quantity, OrderBookListener listener) {
         while (quantity > 0 && !orders.isEmpty()) {
-            Order order = orders.get(0);
+            Order resting = orders.get(0);
 
-            long orderQuantity = order.getRemainingQuantity();
+            long restingQuantity = resting.getRemainingQuantity();
 
-            if (orderQuantity > quantity) {
-                order.reduce(quantity);
+            if (restingQuantity > quantity) {
+                resting.reduce(quantity);
 
-                listener.match(order.getId(), orderId, side, price, quantity, order.getRemainingQuantity());
+                listener.match(resting.getId(), orderId, side, price, quantity, resting.getRemainingQuantity());
 
                 quantity = 0;
             } else {
                 orders.remove(0);
 
-                listener.match(order.getId(), orderId, side, price, orderQuantity, 0);
+                listener.match(resting.getId(), orderId, side, price, restingQuantity, 0);
 
-                quantity -= orderQuantity;
+                quantity -= restingQuantity;
             }
         }
 

--- a/libraries/match/src/test/java/com/paritytrading/parity/match/OrderBookTest.java
+++ b/libraries/match/src/test/java/com/paritytrading/parity/match/OrderBookTest.java
@@ -207,4 +207,17 @@ public class OrderBookTest {
         assertEquals(asList(bid, cancel), events.collect());
     }
 
+    @Test
+    public void reuseOrderId() {
+        book.enter(1, Side.BUY,  1000, 100);
+        book.enter(2, Side.SELL, 1000, 100);
+        book.enter(1, Side.BUY,  1000, 100);
+
+        Event firstBid  = new Add(1, Side.BUY, 1000, 100);
+        Event match     = new Match(1, 2, Side.SELL, 1000, 100, 0);
+        Event secondBid = new Add(1, Side.BUY, 1000, 100);
+
+        assertEquals(asList(firstBid, match, secondBid), events.collect());
+    }
+
 }


### PR DESCRIPTION
Ensure that a resting order is forgotten completely when it is executed fully.

Fixes #122.