### PR TITLE
Switch trade side

### DIFF
--- a/applications/ticker/src/main/java/com/paritytrading/parity/ticker/TAQFormat.java
+++ b/applications/ticker/src/main/java/com/paritytrading/parity/ticker/TAQFormat.java
@@ -87,7 +87,7 @@ class TAQFormat extends MarketDataListener {
     }
 
     private char side(Side side) {
-        return side == Side.BUY ? TAQ.SELL : TAQ.BUY;
+        return side == Side.BUY ? TAQ.BUY : TAQ.SELL;
     }
 
 }

--- a/applications/ticker/src/main/java/com/paritytrading/parity/ticker/TAQFormat.java
+++ b/applications/ticker/src/main/java/com/paritytrading/parity/ticker/TAQFormat.java
@@ -87,7 +87,7 @@ class TAQFormat extends MarketDataListener {
     }
 
     private char side(Side side) {
-        return side == Side.BUY ? TAQ.BUY : TAQ.SELL;
+        return side == Side.BUY ? TAQ.SELL : TAQ.BUY;
     }
 
 }

--- a/libraries/book/src/main/java/com/paritytrading/parity/book/Market.java
+++ b/libraries/book/src/main/java/com/paritytrading/parity/book/Market.java
@@ -161,7 +161,7 @@ public class Market {
 
         long executedQuantity = Math.min(quantity, remainingQuantity);
 
-        listener.trade(book, side, price, executedQuantity);
+        listener.trade(book, contra(side), price, executedQuantity);
 
         book.update(side, order.getPrice(), -executedQuantity);
 
@@ -231,6 +231,10 @@ public class Market {
         orders.remove(orderId);
 
         listener.update(book, bbo);
+    }
+
+    private static Side contra(Side side) {
+        return side == Side.BUY ? Side.SELL : Side.BUY;
     }
 
 }

--- a/libraries/book/src/main/java/com/paritytrading/parity/book/MarketListener.java
+++ b/libraries/book/src/main/java/com/paritytrading/parity/book/MarketListener.java
@@ -17,7 +17,7 @@ public interface MarketListener {
      * An event indicating that a trade has taken place.
      *
      * @param book the order book
-     * @param side the side of the resting order
+     * @param side the side of the incoming order
      * @param price the trade price
      * @param size the trade size
      */

--- a/libraries/book/src/test/java/com/paritytrading/parity/book/MarketTest.java
+++ b/libraries/book/src/test/java/com/paritytrading/parity/book/MarketTest.java
@@ -88,7 +88,7 @@ public class MarketTest {
         Event updateAfterBid       = new Update(INSTRUMENT, true);
         Event updateAfterFirstAsk  = new Update(INSTRUMENT, true);
         Event updateAfterSecondAsk = new Update(INSTRUMENT, false);
-        Event trade                = new Trade(INSTRUMENT, Side.SELL, 1001, 200);
+        Event trade                = new Trade(INSTRUMENT, Side.BUY, 1001, 200);
         Event updateAfterTrade     = new Update(INSTRUMENT, true);
 
         assertEquals(asList(updateAfterBid, updateAfterFirstAsk, updateAfterSecondAsk,
@@ -107,7 +107,7 @@ public class MarketTest {
         Event updateAfterBid       = new Update(INSTRUMENT, true);
         Event updateAfterFirstAsk  = new Update(INSTRUMENT, true);
         Event updateAfterSecondAsk = new Update(INSTRUMENT, false);
-        Event trade                = new Trade(INSTRUMENT, Side.SELL, 1000, 200);
+        Event trade                = new Trade(INSTRUMENT, Side.BUY, 1000, 200);
         Event updateAfterTrade     = new Update(INSTRUMENT, true);
 
         assertEquals(asList(updateAfterBid, updateAfterFirstAsk, updateAfterSecondAsk,
@@ -124,7 +124,7 @@ public class MarketTest {
 
         Event updateAfterBid   = new Update(INSTRUMENT, true);
         Event updateAfterAsk   = new Update(INSTRUMENT, true);
-        Event trade            = new Trade(INSTRUMENT, Side.SELL, 1001, 100);
+        Event trade            = new Trade(INSTRUMENT, Side.BUY, 1001, 100);
         Event updateAfterTrade = new Update(INSTRUMENT, true);
 
         assertEquals(asList(updateAfterBid, updateAfterAsk, trade, updateAfterTrade),

--- a/libraries/file/doc/TAQ.md
+++ b/libraries/file/doc/TAQ.md
@@ -26,7 +26,7 @@ using decimal point.
 A record consists of the fields enumerated below.
 
 Name        | Presence | Notes
-------------|----------|------------------------------------------------
+------------|----------|-------------------------------------------------
 Date        | `Q`, `T` |
 Timestamp   | `Q`, `T` |
 Instrument  | `Q`, `T` |
@@ -37,7 +37,7 @@ Ask Price   | `Q`      | Empty if not available
 Ask Size    | `Q`      | Empty if not available
 Trade Price | `T`      |
 Trade Size  | `T`      |
-Trade Side  | `T`      | Refers to resting order, empty if not available
+Trade Side  | `T`      | Refers to incoming order, empty if not available
 
 The record types are enumerated below.
 


### PR DESCRIPTION
Make the trade side refer to the incoming order rather than the resting order in the order book reconstruction as well as the TAQ file format.