### PR TITLE
Remove Eclipse Collections

### DIFF
--- a/applications/client/pom.xml
+++ b/applications/client/pom.xml
@@ -48,14 +48,6 @@
       <groupId>org.jvirtanen.util</groupId>
       <artifactId>util-extras</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.eclipse.collections</groupId>
-      <artifactId>eclipse-collections-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.collections</groupId>
-      <artifactId>eclipse-collections</artifactId>
-    </dependency>
   </dependencies>
 
   <build>
@@ -71,15 +63,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
-          <filters>
-            <filter>
-              <artifact>*:*</artifact>
-              <excludes>
-                <exclude>META-INF/ECLIPSE_.RSA</exclude>
-                <exclude>META-INF/ECLIPSE_.SF</exclude>
-              </excludes>
-            </filter>
-          </filters>
           <outputFile>parity-client.jar</outputFile>
           <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/applications/client/src/main/java/com/paritytrading/parity/client/TerminalClient.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/TerminalClient.java
@@ -85,7 +85,7 @@ public class TerminalClient implements Closeable {
 
     public void run() throws IOException {
         LineReader reader = LineReaderBuilder.builder()
-            .completer(new StringsCompleter(Commands.names().castToList()))
+            .completer(new StringsCompleter(Commands.names()))
             .build();
 
         printf("Type 'help' for help.\n");

--- a/applications/client/src/main/java/com/paritytrading/parity/client/command/Commands.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/command/Commands.java
@@ -1,35 +1,37 @@
 package com.paritytrading.parity.client.command;
 
 import com.paritytrading.parity.net.poe.POE;
-import org.eclipse.collections.api.list.ImmutableList;
-import org.eclipse.collections.impl.factory.Lists;
+import java.util.stream.Stream;
 
 public class Commands {
 
-    private static final ImmutableList<Command> COMMANDS = Lists.immutable.of(
-            new EnterCommand(POE.BUY),
-            new EnterCommand(POE.SELL),
-            new CancelCommand(),
-            new OrdersCommand(),
-            new TradesCommand(),
-            new ErrorsCommand(),
-            new HelpCommand(),
-            new ExitCommand()
-        );
+    private static final Command[] COMMANDS = new Command[] {
+        new EnterCommand(POE.BUY),
+        new EnterCommand(POE.SELL),
+        new CancelCommand(),
+        new OrdersCommand(),
+        new TradesCommand(),
+        new ErrorsCommand(),
+        new HelpCommand(),
+        new ExitCommand(),
+    };
 
     private Commands() {
     }
 
-    public static ImmutableList<Command> all() {
+    public static Command[] all() {
         return COMMANDS;
     }
 
     public static Command find(final String name) {
-        return COMMANDS.select(c -> c.getName().equals(name)).getFirst();
+        return Stream.of(COMMANDS)
+                .filter(c -> c.getName().equals(name))
+                .findFirst()
+                .orElse(null);
     }
 
-    public static ImmutableList<String> names() {
-        return COMMANDS.collect(Command::getName);
+    public static String[] names() {
+        return Stream.of(COMMANDS).map(Command::getName).toArray(String[]::new);
     }
 
 }

--- a/applications/client/src/main/java/com/paritytrading/parity/client/command/HelpCommand.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/command/HelpCommand.java
@@ -2,6 +2,7 @@ package com.paritytrading.parity.client.command;
 
 import com.paritytrading.parity.client.TerminalClient;
 import java.util.Scanner;
+import java.util.stream.Stream;
 
 class HelpCommand implements Command {
 
@@ -38,7 +39,7 @@ class HelpCommand implements Command {
     }
 
     private int calculateMaxCommandNameLength() {
-        return Commands.names().collectInt(String::length).max();
+        return Stream.of(Commands.names()).mapToInt(String::length).max().orElse(0);
     }
 
     @Override

--- a/applications/client/src/main/java/com/paritytrading/parity/client/event/Errors.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/event/Errors.java
@@ -1,18 +1,17 @@
 package com.paritytrading.parity.client.event;
 
-import org.eclipse.collections.api.list.ImmutableList;
-import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.factory.Lists;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Errors extends DefaultEventVisitor {
 
-    private MutableList<Error> errors;
+    private List<Error> errors;
 
     private Errors() {
-        errors = Lists.mutable.with();
+        errors = new ArrayList<>();
     }
 
-    public static ImmutableList<Error> collect(Events events) {
+    public static List<Error> collect(Events events) {
         Errors visitor = new Errors();
 
         events.accept(visitor);
@@ -20,8 +19,8 @@ public class Errors extends DefaultEventVisitor {
         return visitor.getEvents();
     }
 
-    private ImmutableList<Error> getEvents() {
-        return errors.toImmutable();
+    private List<Error> getEvents() {
+        return errors;
     }
 
     @Override

--- a/applications/client/src/main/java/com/paritytrading/parity/client/event/Events.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/event/Events.java
@@ -2,18 +2,18 @@ package com.paritytrading.parity.client.event;
 
 import com.paritytrading.parity.net.poe.POE;
 import com.paritytrading.parity.net.poe.POEClientListener;
-import org.eclipse.collections.api.list.ImmutableList;
-import org.eclipse.collections.impl.factory.Lists;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Events implements POEClientListener {
 
-    private volatile ImmutableList<Event> events;
+    private List<Event> events;
 
     public Events() {
-        events = Lists.immutable.with();
+        events = new ArrayList<>();
     }
 
-    public void accept(EventVisitor visitor) {
+    public synchronized void accept(EventVisitor visitor) {
         for (Event event : events)
             event.accept(visitor);
     }
@@ -38,8 +38,8 @@ public class Events implements POEClientListener {
         add(new Event.OrderCanceled(message));
     }
 
-    private void add(Event event) {
-        events = events.newWith(event);
+    private synchronized void add(Event event) {
+        events.add(event);
     }
 
 }

--- a/applications/client/src/main/java/com/paritytrading/parity/client/event/Orders.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/event/Orders.java
@@ -1,18 +1,22 @@
 package com.paritytrading.parity.client.event;
 
-import org.eclipse.collections.api.list.ImmutableList;
-import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.impl.factory.Maps;
+import static java.util.Comparator.*;
+import static java.util.stream.Collectors.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class Orders extends DefaultEventVisitor {
 
-    private MutableMap<String, Order> orders;
+    private Map<String, Order> orders;
 
     private Orders() {
-        orders = Maps.mutable.with();
+        orders = new HashMap<>();
     }
 
-    public static ImmutableList<Order> collect(Events events) {
+    public static List<Order> collect(Events events) {
         Orders visitor = new Orders();
 
         events.accept(visitor);
@@ -20,9 +24,11 @@ public class Orders extends DefaultEventVisitor {
         return visitor.getEvents();
     }
 
-    private ImmutableList<Order> getEvents() {
-        return orders.valuesView().toSortedList((a, b) ->
-                Long.compare(a.getTimestamp(), b.getTimestamp())).toImmutable();
+    private List<Order> getEvents() {
+        return orders.values()
+                .stream()
+                .sorted(comparing(Order::getTimestamp))
+                .collect(toList());
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <jmh.version>1.19</jmh.version>
-    <eclipse.collections.version>8.2.0</eclipse.collections.version>
     <nassau.version>0.13.0</nassau.version> <!-- (mentioned in documentation) -->
     <philadelphia.version>1.0.0</philadelphia.version>
   </properties>
@@ -102,16 +101,6 @@
         <artifactId>junit</artifactId>
         <version>4.12</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.collections</groupId>
-        <artifactId>eclipse-collections-api</artifactId>
-        <version>${eclipse.collections.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.collections</groupId>
-        <artifactId>eclipse-collections</artifactId>
-        <version>${eclipse.collections.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jvirtanen.config</groupId>


### PR DESCRIPTION
The usage of Eclipse Collections in Parity precedes Java 8. Replace Eclipse Collections with the `java.util.stream` package.