### PR TITLE
Suppress 'unused' warnings

### DIFF
--- a/libraries/book/src/test/java/com/paritytrading/parity/book/MarketTest.java
+++ b/libraries/book/src/test/java/com/paritytrading/parity/book/MarketTest.java
@@ -201,6 +201,7 @@ public class MarketTest {
                     updateAfterFirstDelete, updateAfterSecondDelete), events.collect());
     }
 
+    @SuppressWarnings("unused")
     private static class Level extends Value {
         public final long bidPrice;
         public final long bidSize;


### PR DESCRIPTION
Suppress 'unused' warnings for `Level`'s member variables which are used reflectively via the parent class `Value`'s implementation of `equals` and `hashCode`.